### PR TITLE
Refactor/new simcore lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ message(STATUS "${PROJECT_NAME}: Generating build version ${msg_VERSION}")
 # Begin project dependencies ------------------------------------------------------
 set(
     IM_SAMPLE_ALGORITHM_AIRCRAFT_SIMULATION_CORE_TAG
-    "7d515ad21ecc7d4d5c9d25af23fc7c7d0764d8bc" # TODO switch to "2.0.0" when released
+    "139d294b5bdc3b53d8a930a717e60bd5bb8eabaf" # TODO switch to "2.0.0" when released
     CACHE STRING "aircraft_simulation_core tag used for im_sample_algorithm builds"
 )
 set(IM_SAMPLE_ALGORITHM_FSLOADER_TAG "1.1.0" CACHE STRING "fsloader tag used for im_sample_algorithm builds")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ message(STATUS "${PROJECT_NAME}: Generating build version ${msg_VERSION}")
 # Begin project dependencies ------------------------------------------------------
 set(
     IM_SAMPLE_ALGORITHM_AIRCRAFT_SIMULATION_CORE_TAG
-    "feat/aircraft-intent-builder" # TODO switch to "2.0.0" when released
+    "7d515ad21ecc7d4d5c9d25af23fc7c7d0764d8bc" # TODO switch to "2.0.0" when released
     CACHE STRING "aircraft_simulation_core tag used for im_sample_algorithm builds"
 )
 set(IM_SAMPLE_ALGORITHM_FSLOADER_TAG "1.1.0" CACHE STRING "fsloader tag used for im_sample_algorithm builds")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ message(STATUS "${PROJECT_NAME}: Generating build version ${msg_VERSION}")
 # Begin project dependencies ------------------------------------------------------
 set(
     IM_SAMPLE_ALGORITHM_AIRCRAFT_SIMULATION_CORE_TAG
-    "139d294b5bdc3b53d8a930a717e60bd5bb8eabaf" # TODO switch to "2.0.0" when released
+    "3ba90f5fd518f5e3f717df98b1aff59826c9ed31" # TODO switch to "2.0.0" when released
     CACHE STRING "aircraft_simulation_core tag used for im_sample_algorithm builds"
 )
 set(IM_SAMPLE_ALGORITHM_FSLOADER_TAG "1.1.0" CACHE STRING "fsloader tag used for im_sample_algorithm builds")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ message(STATUS "${PROJECT_NAME}: Generating build version ${msg_VERSION}")
 # Begin project dependencies ------------------------------------------------------
 set(
     IM_SAMPLE_ALGORITHM_AIRCRAFT_SIMULATION_CORE_TAG
-    "2.0.0"
+    "73412470472c1eedf57b655045c9137d398861db" # TODO switch to "2.0.0" when released
     CACHE STRING "aircraft_simulation_core tag used for im_sample_algorithm builds"
 )
 set(IM_SAMPLE_ALGORITHM_FSLOADER_TAG "1.1.0" CACHE STRING "fsloader tag used for im_sample_algorithm builds")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ message(STATUS "${PROJECT_NAME}: Generating build version ${msg_VERSION}")
 # Begin project dependencies ------------------------------------------------------
 set(
     IM_SAMPLE_ALGORITHM_AIRCRAFT_SIMULATION_CORE_TAG
-    "8a24a6dc6f37ade7f605c2ea2270dbf0b142e738" # TODO switch to "2.0.0" when released
+    "0f4307129968f638c5cd84ff4fc6af2fb5e3d49c" # TODO switch to "2.0.0" when released
     CACHE STRING "aircraft_simulation_core tag used for im_sample_algorithm builds"
 )
 set(IM_SAMPLE_ALGORITHM_FSLOADER_TAG "1.1.0" CACHE STRING "fsloader tag used for im_sample_algorithm builds")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.26...4.2)
-project(im_sample_algorithm VERSION 5.3.2 LANGUAGES CXX)
+project(im_sample_algorithm VERSION 5.4.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.26...4.2)
-project(im_sample_algorithm VERSION 5.4.0 LANGUAGES CXX)
+project(im_sample_algorithm VERSION 6.0.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -34,7 +34,7 @@ message(STATUS "${PROJECT_NAME}: Generating build version ${msg_VERSION}")
 # Begin project dependencies ------------------------------------------------------
 set(
     IM_SAMPLE_ALGORITHM_AIRCRAFT_SIMULATION_CORE_TAG
-    "6abbdc40e11e1ef8b1f77670e14498dbd88a1fc6" # TODO switch to "2.0.0" when released
+    "2.0.0"
     CACHE STRING "aircraft_simulation_core tag used for im_sample_algorithm builds"
 )
 set(IM_SAMPLE_ALGORITHM_FSLOADER_TAG "1.1.0" CACHE STRING "fsloader tag used for im_sample_algorithm builds")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ message(STATUS "${PROJECT_NAME}: Generating build version ${msg_VERSION}")
 # Begin project dependencies ------------------------------------------------------
 set(
     IM_SAMPLE_ALGORITHM_AIRCRAFT_SIMULATION_CORE_TAG
-    "1.0.0"
+    "2.0.0"
     CACHE STRING "aircraft_simulation_core tag used for im_sample_algorithm builds"
 )
 set(IM_SAMPLE_ALGORITHM_FSLOADER_TAG "1.1.0" CACHE STRING "fsloader tag used for im_sample_algorithm builds")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ message(STATUS "${PROJECT_NAME}: Generating build version ${msg_VERSION}")
 # Begin project dependencies ------------------------------------------------------
 set(
     IM_SAMPLE_ALGORITHM_AIRCRAFT_SIMULATION_CORE_TAG
-    "94ed0cd1da6241bc31762b945324918f1698864a" # TODO switch to "2.0.0" when released
+    "8a24a6dc6f37ade7f605c2ea2270dbf0b142e738" # TODO switch to "2.0.0" when released
     CACHE STRING "aircraft_simulation_core tag used for im_sample_algorithm builds"
 )
 set(IM_SAMPLE_ALGORITHM_FSLOADER_TAG "1.1.0" CACHE STRING "fsloader tag used for im_sample_algorithm builds")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ message(STATUS "${PROJECT_NAME}: Generating build version ${msg_VERSION}")
 # Begin project dependencies ------------------------------------------------------
 set(
     IM_SAMPLE_ALGORITHM_AIRCRAFT_SIMULATION_CORE_TAG
-    "73412470472c1eedf57b655045c9137d398861db" # TODO switch to "2.0.0" when released
+    "feat/aircraft-intent-builder" # TODO switch to "2.0.0" when released
     CACHE STRING "aircraft_simulation_core tag used for im_sample_algorithm builds"
 )
 set(IM_SAMPLE_ALGORITHM_FSLOADER_TAG "1.1.0" CACHE STRING "fsloader tag used for im_sample_algorithm builds")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ message(STATUS "${PROJECT_NAME}: Generating build version ${msg_VERSION}")
 # Begin project dependencies ------------------------------------------------------
 set(
     IM_SAMPLE_ALGORITHM_AIRCRAFT_SIMULATION_CORE_TAG
-    "3ba90f5fd518f5e3f717df98b1aff59826c9ed31" # TODO switch to "2.0.0" when released
+    "94ed0cd1da6241bc31762b945324918f1698864a" # TODO switch to "2.0.0" when released
     CACHE STRING "aircraft_simulation_core tag used for im_sample_algorithm builds"
 )
 set(IM_SAMPLE_ALGORITHM_FSLOADER_TAG "1.1.0" CACHE STRING "fsloader tag used for im_sample_algorithm builds")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ message(STATUS "${PROJECT_NAME}: Generating build version ${msg_VERSION}")
 # Begin project dependencies ------------------------------------------------------
 set(
     IM_SAMPLE_ALGORITHM_AIRCRAFT_SIMULATION_CORE_TAG
-    "0f4307129968f638c5cd84ff4fc6af2fb5e3d49c" # TODO switch to "2.0.0" when released
+    "6abbdc40e11e1ef8b1f77670e14498dbd88a1fc6" # TODO switch to "2.0.0" when released
     CACHE STRING "aircraft_simulation_core tag used for im_sample_algorithm builds"
 )
 set(IM_SAMPLE_ALGORITHM_FSLOADER_TAG "1.1.0" CACHE STRING "fsloader tag used for im_sample_algorithm builds")

--- a/IntervalManagement/AchievePointCalcs.cpp
+++ b/IntervalManagement/AchievePointCalcs.cpp
@@ -30,7 +30,7 @@
 #include "utility/CustomUnits.h"
 
 using namespace std;
-using namespace aaesim::open_source;
+using namespace mitre::oss::simcore;
 using namespace interval_management::open_source;
 
 #define SQR(x)           \

--- a/IntervalManagement/AchievePointCalcs.cpp
+++ b/IntervalManagement/AchievePointCalcs.cpp
@@ -115,13 +115,14 @@ void AchievePointCalcs::ComputeDefaultTRP(const AchievePointCalcs &ownship_calcs
                                           Waypoint &traffic_reference_point, Units::Length &waypoint_x,
                                           Units::Length &waypoint_y, size_t &waypoint_index_in_target_intent) {
    // Get ABP index from ownship
-   int ix0 = ownship_intent.GetWaypointIndexByName(ownship_calcs.GetWaypointName());
-   if (ix0 < 0) {
+   const auto achieve_by_index = ownship_intent.GetWaypointIndexByName(ownship_calcs.GetWaypointName());
+   if (!achieve_by_index) {
       string emsg = "Illegal ownship achieve-by point " + ownship_calcs.GetWaypointName() +
                     " encountered while computing achieve point calculations positions";
       LOG4CPLUS_FATAL(AchievePointCalcs::m_logger, emsg);
       throw logic_error(emsg);
    }
+   int ix0 = static_cast<int>(*achieve_by_index);
 
    int ix1 = ix0 + 1;
    if (ix1 >= ownship_intent.GetNumberOfWaypoints()) {
@@ -376,13 +377,14 @@ void AchievePointCalcs::ComputeDefaultTRP(const AchievePointCalcs &ownship_calcs
       try {
          distance_calculator.CalculateAlongPathDistanceFromPosition(x, y, distance_to_end);
       } catch (std::logic_error &e) {
-         LOG4CPLUS_ERROR(m_logger, target_intent.GetWaypointName(i)
+         LOG4CPLUS_ERROR(m_logger, target_intent.GetWaypointName(i).value_or("<unknown>")
                                          << " at (" << x << "," << y << ") is not on horizontal path.");
          continue;
       }
       Units::MetersLength distance_to_trp = distance_to_end - distance_trp_to_end;
       LOG4CPLUS_TRACE(m_logger,
-                      "Distance from " << target_intent.GetWaypointName(i) << " to TRP is " << distance_to_trp);
+                      "Distance from " << target_intent.GetWaypointName(i).value_or("<unknown>")
+                                       << " to TRP is " << distance_to_trp);
       if (distance_to_trp <= Units::MetersLength(100)) {
          waypoint_index_in_target_intent = i;
          break;
@@ -394,18 +396,18 @@ void AchievePointCalcs::ComputeDefaultTRP(const AchievePointCalcs &ownship_calcs
 
 void AchievePointCalcs::ComputePositions(const AircraftIntent &intent) {
    if (this->HasWaypoint()) {
-      int ix = intent.GetWaypointIndexByName(m_waypoint_name);
+      const auto waypoint_index = intent.GetWaypointIndexByName(m_waypoint_name);
 
-      if (ix > -1) {
-         m_waypoint_x = Units::MetersLength(intent.GetRouteData().m_x[ix]);
-         m_waypoint_y = Units::MetersLength(intent.GetRouteData().m_y[ix]);
+      if (waypoint_index) {
+         m_waypoint_x = Units::MetersLength(intent.GetRouteData().m_x[*waypoint_index]);
+         m_waypoint_y = Units::MetersLength(intent.GetRouteData().m_y[*waypoint_index]);
       } else {
          string emsg = "Illegal achieve point " + m_waypoint_name +
                        " encountered while computing achieve point calculations positions";
          LOG4CPLUS_FATAL(AchievePointCalcs::m_logger, emsg);
          throw logic_error(emsg);
       }
-      LOG4CPLUS_DEBUG(m_logger, "Waypoint[" << ix << "] = " << m_waypoint_name << "(" << m_waypoint_x << ","
+      LOG4CPLUS_DEBUG(m_logger, "Waypoint[" << *waypoint_index << "] = " << m_waypoint_name << "(" << m_waypoint_x << ","
                                             << m_waypoint_y << ")");
    }
 }

--- a/IntervalManagement/AircraftIntentLoader.cpp
+++ b/IntervalManagement/AircraftIntentLoader.cpp
@@ -60,7 +60,9 @@ bool AircraftIntentLoader::load(DecodedStream *input) {
                       "No waypoints were found in the scenario file. Check the aircraft_intent{} input block.");
       throw std::runtime_error("Must provide waypoints.");
    } else {
-      aircraft_intent_.LoadWaypointsFromList(ascent_waypoints, cruise_waypoints, descent_waypoints);
+      aircraft_intent_.LoadWaypoints({ascent_waypoints.begin(), ascent_waypoints.end()},
+                                     {cruise_waypoints.begin(), cruise_waypoints.end()},
+                                     {descent_waypoints.begin(), descent_waypoints.end()});
    }
 
    return is_loaded_;

--- a/IntervalManagement/AircraftIntentLoader.cpp
+++ b/IntervalManagement/AircraftIntentLoader.cpp
@@ -25,8 +25,9 @@
 #include "imalgs/WaypointLoader.h"
 
 namespace {
-std::list<Waypoint> BuildWaypointList(const std::list<interval_management::loaders::WaypointLoader> &waypoint_loaders) {
-   std::list<Waypoint> waypoints;
+std::list<mitre::oss::simcore::Waypoint>
+BuildWaypointList(const std::list<interval_management::loaders::WaypointLoader> &waypoint_loaders) {
+   std::list<mitre::oss::simcore::Waypoint> waypoints;
    for (const auto &waypoint_loader : waypoint_loaders) {
       waypoints.push_back(waypoint_loader.BuildWaypoint());
    }

--- a/IntervalManagement/AircraftIntentLoader.cpp
+++ b/IntervalManagement/AircraftIntentLoader.cpp
@@ -60,9 +60,11 @@ bool AircraftIntentLoader::load(DecodedStream *input) {
                       "No waypoints were found in the scenario file. Check the aircraft_intent{} input block.");
       throw std::runtime_error("Must provide waypoints.");
    } else {
-      aircraft_intent_.LoadWaypoints({ascent_waypoints.begin(), ascent_waypoints.end()},
-                                     {cruise_waypoints.begin(), cruise_waypoints.end()},
-                                     {descent_waypoints.begin(), descent_waypoints.end()});
+      aircraft_intent_ = open_source::FIMAircraftIntent::Builder()
+                              .LoadWaypoints({ascent_waypoints.begin(), ascent_waypoints.end()},
+                                             {cruise_waypoints.begin(), cruise_waypoints.end()},
+                                             {descent_waypoints.begin(), descent_waypoints.end()})
+                              .Build();
    }
 
    return is_loaded_;

--- a/IntervalManagement/AircraftState.cpp
+++ b/IntervalManagement/AircraftState.cpp
@@ -25,6 +25,8 @@
 #include "public/CustomMath.h"
 #include "utility/CustomUnits.h"
 
+using namespace mitre::oss::simcore;
+
 log4cplus::Logger interval_management::open_source::AircraftState::m_logger =
       log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("AircraftState"));
 

--- a/IntervalManagement/ClosestPointMetric.cpp
+++ b/IntervalManagement/ClosestPointMetric.cpp
@@ -33,7 +33,7 @@ void ClosestPointMetric::update(double imx, double imy, double targx, double tar
    // imx,imy:position of IM aircraft.
    // targx,targy:position of target aircraft.
 
-   Units::Length dist = aaesim::open_source::AircraftCalculations::PtToPtDist(
+   Units::Length dist = mitre::oss::simcore::AircraftCalculations::PtToPtDist(
          Units::FeetLength(imx), Units::FeetLength(imy), Units::FeetLength(targx), Units::FeetLength(targy));
 
    if (dist < mMinDist) {

--- a/IntervalManagement/FIMAlgorithmAdapter.cpp
+++ b/IntervalManagement/FIMAlgorithmAdapter.cpp
@@ -82,9 +82,8 @@ mitre::oss::simcore::Guidance interval_management::open_source::FIMAlgorithmAdap
    mitre::oss::simcore::AircraftState synced_target_state = m_assap->Update(
          own_truth_state, m_assap->GetAdsbReceiver()->GetCurrentADSBReport(GetImClearance().GetTargetId()));
 
-   if (im_algorithm_guidance.GetSelectedSpeed().GetSpeedType() == UNSPECIFIED_SPEED) {
-      im_algorithm_guidance.SetSelectedSpeed(
-            mitre::oss::simcore::AircraftSpeed::OfIndicatedAirspeed(Units::KnotsSpeed(60)));
+   if (im_algorithm_guidance.GetSelectedSpeedType() == UNSPECIFIED_SPEED) {
+      im_algorithm_guidance.SetSelectedSpeedType(INDICATED_AIR_SPEED);
    }
    auto ownship_im_state = ConvertAircraftState(own_truth_state);
    auto target_im_state = ConvertAircraftState(synced_target_state);

--- a/IntervalManagement/FIMAlgorithmAdapter.cpp
+++ b/IntervalManagement/FIMAlgorithmAdapter.cpp
@@ -27,6 +27,7 @@
 #include "imalgs/IMUtils.h"
 #include "nlohmann/json.hpp"
 #include "public/CoreUtils.h"
+#include "public/DefaultAircraftIntent.h"
 #include "public/SingleTangentPlaneSequence.h"
 
 using namespace interval_management::open_source;
@@ -40,14 +41,16 @@ void interval_management::open_source::FIMAlgorithmAdapter::Initialize(
       aaesim::open_source::FlightDeckApplicationInitializer &initializer_visitor) {
    auto ownship_intent_from_clearance = m_im_algorithm->GetClearance().GetOwnshipIntent();
    if (ownship_intent_from_clearance.has_value()) {
-      initializer_visitor.fms_prediction_parameters.fms_intent = ownship_intent_from_clearance.value();
+      initializer_visitor.fms_prediction_parameters.fms_intent =
+            std::make_shared<FIMAircraftIntent>(ownship_intent_from_clearance.value());
    }
-   m_im_algorithm->ValidateClearance(initializer_visitor.fms_prediction_parameters.fms_intent, m_im_algorithm_type);
+   m_im_algorithm->ValidateClearance(*initializer_visitor.fms_prediction_parameters.fms_intent, m_im_algorithm_type);
    initializer_visitor.fms_prediction_parameters.fms_intent =
-         AircraftIntent::CopyAndTrimAfterNamedWaypoint(initializer_visitor.fms_prediction_parameters.fms_intent,
-                                                       m_im_algorithm->GetClearance().GetPlannedTerminationPoint());
-   auto waypoints =
-         CoreUtils::ShortenLongLegs(initializer_visitor.fms_prediction_parameters.fms_intent.GetWaypointList());
+         std::make_shared<DefaultAircraftIntent>(aaesim::open_source::AircraftIntentUtils::CopyAndTrimAfterNamedWaypoint(
+               *initializer_visitor.fms_prediction_parameters.fms_intent,
+               m_im_algorithm->GetClearance().GetPlannedTerminationPoint()));
+   const auto &intent_waypoints = initializer_visitor.fms_prediction_parameters.fms_intent->GetWaypoints();
+   auto waypoints = CoreUtils::ShortenLongLegs(std::list<Waypoint>(intent_waypoints.begin(), intent_waypoints.end()));
    m_position_converter = std::make_unique<SingleTangentPlaneSequence>(waypoints);
    initializer_visitor.position_converter = m_position_converter;
 

--- a/IntervalManagement/FIMAlgorithmAdapter.cpp
+++ b/IntervalManagement/FIMAlgorithmAdapter.cpp
@@ -27,7 +27,6 @@
 #include "imalgs/IMUtils.h"
 #include "nlohmann/json.hpp"
 #include "public/CoreUtils.h"
-#include "public/DefaultAircraftIntent.h"
 #include "public/SingleTangentPlaneSequence.h"
 
 using namespace interval_management::open_source;
@@ -46,9 +45,11 @@ void interval_management::open_source::FIMAlgorithmAdapter::Initialize(
    }
    m_im_algorithm->ValidateClearance(*initializer_visitor.fms_prediction_parameters.fms_intent, m_im_algorithm_type);
    initializer_visitor.fms_prediction_parameters.fms_intent =
-         std::make_shared<DefaultAircraftIntent>(aaesim::open_source::AircraftIntentUtils::CopyAndTrimAfterNamedWaypoint(
-               *initializer_visitor.fms_prediction_parameters.fms_intent,
-               m_im_algorithm->GetClearance().GetPlannedTerminationPoint()));
+         std::make_shared<FIMAircraftIntent>(FIMAircraftIntent::Builder(
+               aaesim::open_source::AircraftIntentUtils::CopyAndTrimAfterNamedWaypoint(
+                     *initializer_visitor.fms_prediction_parameters.fms_intent,
+                     m_im_algorithm->GetClearance().GetPlannedTerminationPoint()))
+                                               .Build());
    const auto &intent_waypoints = initializer_visitor.fms_prediction_parameters.fms_intent->GetWaypoints();
    auto waypoints = CoreUtils::ShortenLongLegs(std::list<Waypoint>(intent_waypoints.begin(), intent_waypoints.end()));
    m_position_converter = std::make_unique<SingleTangentPlaneSequence>(waypoints);

--- a/IntervalManagement/FIMAlgorithmAdapter.cpp
+++ b/IntervalManagement/FIMAlgorithmAdapter.cpp
@@ -37,7 +37,7 @@ interval_management::open_source::FIMAlgorithmAdapter::FIMAlgorithmAdapter(std::
    : m_im_algorithm(im_algorithm), m_im_algorithm_type(algorithm_type) {}
 
 void interval_management::open_source::FIMAlgorithmAdapter::Initialize(
-      aaesim::open_source::FlightDeckApplicationInitializer &initializer_visitor) {
+      mitre::oss::simcore::FlightDeckApplicationInitializer &initializer_visitor) {
    auto ownship_intent_from_clearance = m_im_algorithm->GetClearance().GetOwnshipIntent();
    if (ownship_intent_from_clearance.has_value()) {
       initializer_visitor.fms_prediction_parameters.fms_intent =
@@ -46,7 +46,7 @@ void interval_management::open_source::FIMAlgorithmAdapter::Initialize(
    m_im_algorithm->ValidateClearance(*initializer_visitor.fms_prediction_parameters.fms_intent, m_im_algorithm_type);
    initializer_visitor.fms_prediction_parameters.fms_intent =
          std::make_shared<FIMAircraftIntent>(FIMAircraftIntent::Builder(
-               aaesim::open_source::AircraftIntentUtils::CopyAndTrimAfterNamedWaypoint(
+               mitre::oss::simcore::AircraftIntentUtils::CopyAndTrimAfterNamedWaypoint(
                      *initializer_visitor.fms_prediction_parameters.fms_intent,
                      m_im_algorithm->GetClearance().GetPlannedTerminationPoint()))
                                                .Build());
@@ -68,23 +68,23 @@ void interval_management::open_source::FIMAlgorithmAdapter::Initialize(
    }
 }
 
-aaesim::open_source::Guidance interval_management::open_source::FIMAlgorithmAdapter::Update(
-      const aaesim::open_source::SimulationTime &simtime, const aaesim::open_source::Guidance &current_guidance,
-      const aaesim::open_source::DynamicsState &dynamics_state,
-      const aaesim::open_source::AircraftState &own_truth_state) {
-   aaesim::open_source::Guidance im_algorithm_guidance = current_guidance;
+mitre::oss::simcore::Guidance interval_management::open_source::FIMAlgorithmAdapter::Update(
+      const mitre::oss::simcore::SimulationTime &simtime, const mitre::oss::simcore::Guidance &current_guidance,
+      const mitre::oss::simcore::DynamicsState &dynamics_state,
+      const mitre::oss::simcore::AircraftState &own_truth_state) {
+   mitre::oss::simcore::Guidance im_algorithm_guidance = current_guidance;
    im_algorithm_guidance.SetValid(false);
-   if (current_guidance.m_active_guidance_phase != aaesim::open_source::GuidanceFlightPhase::CRUISE_DESCENT)
+   if (current_guidance.m_active_guidance_phase != mitre::oss::simcore::GuidanceFlightPhase::CRUISE_DESCENT)
       return im_algorithm_guidance;
    if (m_im_algorithm->IsImOperationComplete()) return im_algorithm_guidance;
 
    UpdateTargetHistory(simtime);
-   aaesim::open_source::AircraftState synced_target_state = m_assap->Update(
+   mitre::oss::simcore::AircraftState synced_target_state = m_assap->Update(
          own_truth_state, m_assap->GetAdsbReceiver()->GetCurrentADSBReport(GetImClearance().GetTargetId()));
 
    if (im_algorithm_guidance.GetSelectedSpeed().GetSpeedType() == UNSPECIFIED_SPEED) {
       im_algorithm_guidance.SetSelectedSpeed(
-            aaesim::open_source::AircraftSpeed::OfIndicatedAirspeed(Units::KnotsSpeed(60)));
+            mitre::oss::simcore::AircraftSpeed::OfIndicatedAirspeed(Units::KnotsSpeed(60)));
    }
    auto ownship_im_state = ConvertAircraftState(own_truth_state);
    auto target_im_state = ConvertAircraftState(synced_target_state);
@@ -94,7 +94,7 @@ aaesim::open_source::Guidance interval_management::open_source::FIMAlgorithmAdap
 
 interval_management::open_source::AircraftState
       interval_management::open_source::FIMAlgorithmAdapter::ConvertAircraftState(
-            const aaesim::open_source::AircraftState &state) const {
+            const mitre::oss::simcore::AircraftState &state) const {
    if (state.GetTime().value() < 0 || state.GetUniqueId() == IMUtils::UNINITIALIZED_AIRCRAFT_ID)
       return IMUtils::ConvertToIntervalManagementAircraftState(state);
 
@@ -102,7 +102,7 @@ interval_management::open_source::AircraftState
    m_position_converter->ConvertGeodeticToLocal(
          EarthModel::GeodeticPosition::Of(state.GetLatitude(), state.GetLongitude()), enu_position);
    auto updated_state =
-         aaesim::open_source::AircraftState::Builder(state).Position(enu_position.x, enu_position.y)->Build();
+         mitre::oss::simcore::AircraftState::Builder(state).Position(enu_position.x, enu_position.y)->Build();
    LogAircraftState(updated_state);
    return IMUtils::ConvertToIntervalManagementAircraftState(updated_state);
 }
@@ -112,8 +112,8 @@ bool interval_management::open_source::FIMAlgorithmAdapter::IsActive() const {
 }
 
 void interval_management::open_source::FIMAlgorithmAdapter::UpdateTargetHistory(
-      const aaesim::open_source::SimulationTime &simtime) {
-   std::vector<aaesim::open_source::ADSBSVReport> recent_reports =
+      const mitre::oss::simcore::SimulationTime &simtime) {
+   std::vector<mitre::oss::simcore::ADSBSVReport> recent_reports =
          m_assap->GetAdsbReceiver()->GetReportsReceivedByTime(simtime);
    if (recent_reports.empty()) {
       return;
@@ -122,8 +122,8 @@ void interval_management::open_source::FIMAlgorithmAdapter::UpdateTargetHistory(
    for (const auto &adsb_sv_report : recent_reports) {
       if (adsb_sv_report.GetId() == GetImClearance().GetTargetId()) {
          if (adsb_sv_report.GetTime() >= Units::zero()) {
-            const aaesim::open_source::AircraftState ads_b_state =
-                  aaesim::open_source::AircraftState::FromAdsbReport(adsb_sv_report);
+            const mitre::oss::simcore::AircraftState ads_b_state =
+                  mitre::oss::simcore::AircraftState::FromAdsbReport(adsb_sv_report);
             interval_management::open_source::AircraftState imstate = ConvertAircraftState(ads_b_state);
             imstate.m_distance_to_go_meters = Units::MetersLength(m_im_algorithm->GetTargetDtgToLastWaypoint()).value();
             m_target_history.push_back(imstate);
@@ -132,7 +132,7 @@ void interval_management::open_source::FIMAlgorithmAdapter::UpdateTargetHistory(
    }
 }
 
-void FIMAlgorithmAdapter::LogAircraftState(const aaesim::open_source::AircraftState &state) {
+void FIMAlgorithmAdapter::LogAircraftState(const mitre::oss::simcore::AircraftState &state) {
    if (m_logger.getLogLevel() == log4cplus::TRACE_LOG_LEVEL) {
       json j;
       j["acid"] = state.GetUniqueId();

--- a/IntervalManagement/FIMAlgorithmDataWriter.cpp
+++ b/IntervalManagement/FIMAlgorithmDataWriter.cpp
@@ -134,8 +134,8 @@ void interval_management::open_source::FIMAlgorithmDataWriter::Finish() {
 }
 
 void interval_management::open_source::FIMAlgorithmDataWriter::Gather(
-      const int iteration_number, const aaesim::open_source::SimulationTime &time, const std::string &aircraft_id,
-      std::shared_ptr<const aaesim::open_source::FlightDeckApplication> application) {
+      const int iteration_number, const mitre::oss::simcore::SimulationTime &time, const std::string &aircraft_id,
+      std::shared_ptr<const mitre::oss::simcore::FlightDeckApplication> application) {
    const bool is_fim_application =
          CoreUtils::InstanceOf<interval_management::open_source::FIMAlgorithmAdapter>(application.get());
    if (!is_fim_application) {

--- a/IntervalManagement/FIMAlgorithmInitializer.cpp
+++ b/IntervalManagement/FIMAlgorithmInitializer.cpp
@@ -96,21 +96,21 @@ const interval_management::open_source::FIMAlgorithmInitializer
 
 interval_management::open_source::FIMAlgorithmInitializer::Builder *
       interval_management::open_source::FIMAlgorithmInitializer::Builder::AddOwnshipPerformanceParameters(
-            const aaesim::open_source::OwnshipPerformanceParameters &performance_parameters) {
+            const mitre::oss::simcore::OwnshipPerformanceParameters &performance_parameters) {
    m_performance_parameters = performance_parameters;
    return this;
 }
 
 interval_management::open_source::FIMAlgorithmInitializer::Builder *
       interval_management::open_source::FIMAlgorithmInitializer::Builder::AddOwnshipFmsPredictionParameters(
-            const aaesim::open_source::OwnshipFmsPredictionParameters &prediction_parameters) {
+            const mitre::oss::simcore::OwnshipFmsPredictionParameters &prediction_parameters) {
    m_prediction_parameters = prediction_parameters;
    return this;
 }
 
 interval_management::open_source::FIMAlgorithmInitializer::Builder *
       interval_management::open_source::FIMAlgorithmInitializer::Builder::AddSurveillanceProcessor(
-            std::shared_ptr<const aaesim::open_source::ASSAP> processor) {
+            std::shared_ptr<const mitre::oss::simcore::ASSAP> processor) {
    m_surveillance_processor = processor;
    return this;
 }

--- a/IntervalManagement/FIMAlgorithmInitializer.cpp
+++ b/IntervalManagement/FIMAlgorithmInitializer.cpp
@@ -52,25 +52,25 @@ void interval_management::open_source::FIMAlgorithmInitializer::Initialize(
 
 void interval_management::open_source::FIMAlgorithmInitializer::Initialize(
       interval_management::open_source::IMKinematicAchieve *kinematic_algorithm) {
-   kinematic_algorithm->Initialize(BuildOwnshipPredictionParameters(), fms_prediction_parameters.fms_intent,
+   kinematic_algorithm->Initialize(BuildOwnshipPredictionParameters(), *fms_prediction_parameters.fms_intent,
                                    fms_prediction_parameters.weather_prediction, position_converter);
 }
 
 void interval_management::open_source::FIMAlgorithmInitializer::Initialize(
       interval_management::open_source::IMTimeBasedAchieveMutableASG *test_vector_algorithm) {
-   test_vector_algorithm->Initialize(BuildOwnshipPredictionParameters(), fms_prediction_parameters.fms_intent,
+   test_vector_algorithm->Initialize(BuildOwnshipPredictionParameters(), *fms_prediction_parameters.fms_intent,
                                      fms_prediction_parameters.weather_prediction);
 }
 
 void interval_management::open_source::FIMAlgorithmInitializer::Initialize(
       interval_management::open_source::IMTimeBasedAchieve *time_achieve_algorithm) {
-   time_achieve_algorithm->Initialize(BuildOwnshipPredictionParameters(), fms_prediction_parameters.fms_intent,
+   time_achieve_algorithm->Initialize(BuildOwnshipPredictionParameters(), *fms_prediction_parameters.fms_intent,
                                       fms_prediction_parameters.weather_prediction, position_converter);
 }
 
 void interval_management::open_source::FIMAlgorithmInitializer::Initialize(
       interval_management::open_source::IMDistBasedAchieve *dist_achieve_algorithm) {
-   dist_achieve_algorithm->Initialize(BuildOwnshipPredictionParameters(), fms_prediction_parameters.fms_intent,
+   dist_achieve_algorithm->Initialize(BuildOwnshipPredictionParameters(), *fms_prediction_parameters.fms_intent,
                                       fms_prediction_parameters.weather_prediction, position_converter);
 }
 

--- a/IntervalManagement/FIMSpeedLimiter.cpp
+++ b/IntervalManagement/FIMSpeedLimiter.cpp
@@ -31,10 +31,10 @@ log4cplus::Logger FIMSpeedLimiter::m_logger = log4cplus::Logger::getInstance(LOG
 const BoundedValue<double, 0, 100> FIMSpeedLimiter::DEFAULT_SPEED_DEVIATION_PERCENTAGE(10);
 
 FIMSpeedLimiter::FIMSpeedLimiter(bool use_speed_quantization, bool use_speed_limiting,
-                                 aaesim::open_source::bada_utils::FlapSpeeds flap_speeds,
-                                 aaesim::open_source::bada_utils::FlightEnvelope flight_envelope,
-                                 aaesim::open_source::bada_utils::Mass mass_data,
-                                 const aaesim::open_source::bada_utils::Aerodynamics &aerodynamics,
+                                 mitre::oss::simcore::bada_utils::FlapSpeeds flap_speeds,
+                                 mitre::oss::simcore::bada_utils::FlightEnvelope flight_envelope,
+                                 mitre::oss::simcore::bada_utils::Mass mass_data,
+                                 const mitre::oss::simcore::bada_utils::Aerodynamics &aerodynamics,
                                  const FIMSpeedQuantizer &speed_quantizer)
    : m_rf_leg_limits(),
      m_active_filter_flag(0L),
@@ -63,7 +63,7 @@ Units::Speed FIMSpeedLimiter::LimitSpeedCommand(
       const Units::Speed previous_ias_speed_command, const Units::Speed current_ias_speed_command,
       const Units::Speed nominal_reference_speed, const Units::Length distance_to_go_to_abp,
       const Units::Length distance_to_end_of_route, const Units::Length ownship_altitude,
-      const aaesim::open_source::bada_utils::FlapConfiguration flap_configuration) {
+      const mitre::oss::simcore::bada_utils::FlapConfiguration flap_configuration) {
    Units::Speed limitedspeed = current_ias_speed_command;
    Units::Speed llim = Units::ZERO_SPEED;
    Units::Speed hlim = Units::ZERO_SPEED;
@@ -153,16 +153,16 @@ Units::Speed FIMSpeedLimiter::LimitSpeedCommand(
       m_active_filter_flag |= 256;
    }
 
-   if (flap_configuration > aaesim::open_source::bada_utils::FlapConfiguration::CRUISE) {
-      if (flap_configuration == aaesim::open_source::bada_utils::FlapConfiguration::APPROACH &&
+   if (flap_configuration > mitre::oss::simcore::bada_utils::FlapConfiguration::CRUISE) {
+      if (flap_configuration == mitre::oss::simcore::bada_utils::FlapConfiguration::APPROACH &&
           limitedspeed > m_flap_speeds.cas_approach_maximum) {
          limitedspeed = m_flap_speeds.cas_approach_maximum;
          m_active_filter_flag |= 512;
-      } else if (flap_configuration == aaesim::open_source::bada_utils::FlapConfiguration::LANDING &&
+      } else if (flap_configuration == mitre::oss::simcore::bada_utils::FlapConfiguration::LANDING &&
                  limitedspeed > m_flap_speeds.cas_landing_maximum) {
          limitedspeed = m_flap_speeds.cas_landing_maximum;
          m_active_filter_flag |= 512;
-      } else if (flap_configuration == aaesim::open_source::bada_utils::FlapConfiguration::GEAR_DOWN &&
+      } else if (flap_configuration == mitre::oss::simcore::bada_utils::FlapConfiguration::GEAR_DOWN &&
                  limitedspeed > m_flap_speeds.cas_gear_out_maximum) {
          limitedspeed = m_flap_speeds.cas_gear_out_maximum;
          m_active_filter_flag |= 512;
@@ -184,7 +184,7 @@ BoundedValue<double, 0, 2> FIMSpeedLimiter::LimitMachCommand(
       const BoundedValue<double, 0, 2> &previous_reference_speed_command_mach,
       const BoundedValue<double, 0, 2> &current_mach_command, const BoundedValue<double, 0, 2> &nominal_mach,
       const Units::Mass &current_mass, const Units::Length &current_ownship_altitude,
-      const aaesim::open_source::WeatherPrediction &weather_prediction) {
+      const mitre::oss::simcore::WeatherPrediction &weather_prediction) {
    BoundedValue<double, 0, 2> limited_mach = current_mach_command;
    BoundedValue<double, 0, 2> maximum_mach(m_aircraft_flight_envelope.M_mo);
    m_active_filter_flag = 0L;

--- a/IntervalManagement/IMAchieve.cpp
+++ b/IntervalManagement/IMAchieve.cpp
@@ -32,7 +32,7 @@ using namespace interval_management::open_source;
 
 log4cplus::Logger IMAchieve::m_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("IMAchieve"));
 
-const shared_ptr<aaesim::open_source::PredictedWindEvaluator> IMAchieve::m_predicted_wind_evaluator(
+const shared_ptr<mitre::oss::simcore::PredictedWindEvaluator> IMAchieve::m_predicted_wind_evaluator(
       MOPSPredictedWindEvaluatorVersion2::GetInstance());
 
 // Do not change these values without discussing with Lesley Weitz.
@@ -91,8 +91,8 @@ void IMAchieve::IterationReset() {
    IterClearIMAch();
 }
 
-aaesim::open_source::Guidance IMAchieve::Update(
-      const aaesim::open_source::Guidance &prevguidance, const aaesim::open_source::DynamicsState &dynamicsstate,
+mitre::oss::simcore::Guidance IMAchieve::Update(
+      const mitre::oss::simcore::Guidance &prevguidance, const mitre::oss::simcore::DynamicsState &dynamicsstate,
       const interval_management::open_source::AircraftState &owntruthstate,
       const interval_management::open_source::AircraftState &targettruthstate,
       const vector<interval_management::open_source::AircraftState> &targethistory) {
@@ -124,7 +124,7 @@ void IMAchieve::DumpParameters(const string &parameters_to_print) {
 
 void IMAchieve::Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                            const AircraftIntent &ownship_aircraft_intent,
-                           aaesim::open_source::WeatherPrediction &weather_prediction) {
+                           mitre::oss::simcore::WeatherPrediction &weather_prediction) {
    IMAlgorithm::Initialize(ownship_prediction_parameters, ownship_aircraft_intent, weather_prediction);
 
    m_achieve_by_point.assign(m_im_clearance.GetAchieveByPoint());

--- a/IntervalManagement/IMAlgorithm.cpp
+++ b/IntervalManagement/IMAlgorithm.cpp
@@ -202,7 +202,7 @@ void IMAlgorithm::Initialize(const OwnshipPredictionParameters &ownship_predicti
    SetAssignedSpacingGoal(m_im_clearance);
    // Check whether m_target_aircraft_intent was initialized by a subclass
    if (!m_target_aircraft_intent.IsLoaded()) {
-      m_target_aircraft_intent = m_im_clearance.GetTargetAircraftIntent();
+      m_target_aircraft_intent = FIMAircraftIntent::Builder(m_im_clearance.GetTargetAircraftIntent()).Build();
    }
    SetWeatherPrediction(weather_prediction);
 

--- a/IntervalManagement/IMAlgorithm.cpp
+++ b/IntervalManagement/IMAlgorithm.cpp
@@ -30,7 +30,7 @@
 #include "public/CoreUtils.h"
 #include "public/CustomMath.h"
 
-using namespace aaesim::open_source;
+using namespace mitre::oss::simcore;
 using namespace interval_management::open_source;
 
 log4cplus::Logger IMAlgorithm::m_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("IMAlgorithm"));
@@ -214,15 +214,15 @@ void IMAlgorithm::ResetDefaults() {
    // TODO remove this function
 }
 
-aaesim::open_source::Guidance IMAlgorithm::Update(
-      const aaesim::open_source::Guidance &prevguidance, const aaesim::open_source::DynamicsState &dynamicsstate,
+mitre::oss::simcore::Guidance IMAlgorithm::Update(
+      const mitre::oss::simcore::Guidance &prevguidance, const mitre::oss::simcore::DynamicsState &dynamicsstate,
       const interval_management::open_source::AircraftState &owntruthstate,
       const interval_management::open_source::AircraftState &targettruthstate,
       const std::vector<interval_management::open_source::AircraftState> &targethistory) {
    return prevguidance;
 }
 
-void IMAlgorithm::SetPilotDelay(aaesim::open_source::StatisticalPilotDelay &pilot_delay) {
+void IMAlgorithm::SetPilotDelay(mitre::oss::simcore::StatisticalPilotDelay &pilot_delay) {
    m_pilot_delay = std::move(pilot_delay);
 }
 

--- a/IntervalManagement/IMClearance.cpp
+++ b/IntervalManagement/IMClearance.cpp
@@ -82,11 +82,14 @@ bool IMClearance::Validate(const AircraftIntent &ownship_aircraft_intent,
       if (m_valid) {
          if (m_planned_termination_point.empty()) {
             m_valid = true;
-            const string lastWptName =
+            const auto lastWptName =
                   ownship_aircraft_intent.GetWaypointName(ownship_aircraft_intent.GetNumberOfWaypoints() - 1);
-            string infomsg = "The planned termination point is empty. It is forced to: " + lastWptName;
+            if (!lastWptName) {
+               throw LoadError("The ownship intent has no final waypoint.");
+            }
+            string infomsg = "The planned termination point is empty. It is forced to: " + *lastWptName;
             LOG4CPLUS_INFO(m_logger, infomsg);
-            m_planned_termination_point = lastWptName;
+            m_planned_termination_point = *lastWptName;
          } else {
             m_valid = ValidatePlannedTerminationPoint(ownship_aircraft_intent, im_algorithm_type);
          }
@@ -151,9 +154,12 @@ bool IMClearance::ValidateFinalApproachSpacingClearance(const AircraftIntent &ow
    // AAES-632 changed the way FAS is handled.
    //   PTP does not have to be the same as TRP (parallel runway approaches)
    //   merge point only added to aircraft on-vector
-   const bool isLastWptNameOwnship =
-         ownship_aircraft_intent.GetWaypointName(ownship_aircraft_intent.GetNumberOfWaypoints() - 1) ==
-         m_planned_termination_point;
+   const auto last_waypoint_name =
+         ownship_aircraft_intent.GetWaypointName(ownship_aircraft_intent.GetNumberOfWaypoints() - 1);
+   if (!last_waypoint_name) {
+      throw LoadError("For FAS, the ownship intent must have a final waypoint.");
+   }
+   const bool isLastWptNameOwnship = *last_waypoint_name == m_planned_termination_point;
 
    if (!isLastWptNameOwnship) {
       const string msg = "For FAS, the Planned Termination Point (" + m_planned_termination_point +
@@ -194,8 +200,7 @@ bool IMClearance::ValidateFinalApproachSpacingClearance(const AircraftIntent &ow
       }
    }
 
-   if (ownship_aircraft_intent.GetWaypointName(ownship_aircraft_intent.GetNumberOfWaypoints() - 1) !=
-       m_achieve_by_point) {
+   if (*last_waypoint_name != m_achieve_by_point) {
       const string msg = "For FAS, The ABP must be the final waypoint and it is not. This intent is malformed.";
       LOG4CPLUS_FATAL(m_logger, msg);
       throw LoadError(msg);
@@ -267,7 +272,7 @@ void IMClearance::SetFinalApproachSpacingMergeAngleStd(Units::Angle final_approa
 
 bool IMClearance::ValidatePlannedTerminationPoint(const AircraftIntent &ownship_aircraft_intent,
                                                   const IMUtils::IMAlgorithmTypes im_algorithm_type) const {
-   if (ownship_aircraft_intent.GetWaypointIndexByName(m_planned_termination_point) < 0) {
+   if (!ownship_aircraft_intent.GetWaypointIndexByName(m_planned_termination_point)) {
       const string msg =
             "The planned termination point, " + m_planned_termination_point + ", was not found in the ownship intent.";
       LOG4CPLUS_FATAL(m_logger, msg);
@@ -298,8 +303,7 @@ bool IMClearance::ValidateTrafficReferencePoint(const AircraftIntent &ownship_ai
          // throw LoadError(msg);
          m_traffic_reference_point = "CALCULATED_TRP";
       } else {
-         const int idx = m_target_aircraft_intent.GetWaypointIndexByName(m_traffic_reference_point);
-         if (idx < 0) {
+         if (!m_target_aircraft_intent.GetWaypointIndexByName(m_traffic_reference_point)) {
             std::string msg = "The Traffic-Reference-Point has not been found in the target intent. Looked for " +
                               m_traffic_reference_point + ".";
             LOG4CPLUS_FATAL(m_logger, msg);

--- a/IntervalManagement/IMClearance.cpp
+++ b/IntervalManagement/IMClearance.cpp
@@ -171,28 +171,24 @@ bool IMClearance::ValidateFinalApproachSpacingClearance(const AircraftIntent &ow
    if (m_is_vector_aircraft) {
       if (ownship_aircraft_intent.GetNumberOfWaypoints() < 2) {
          const string msg = "For FAS, The on-vector ownship intent is too small. It must be malformed.";
-         ownship_aircraft_intent.DumpParms("ownship intent:");
          LOG4CPLUS_FATAL(m_logger, msg);
          throw LoadError(msg);
       }
 
       if (m_target_aircraft_intent.GetNumberOfWaypoints() != 2) {
          const string msg = "For FAS, The on-final target intent is not 2. It must be malformed.";
-         m_target_aircraft_intent.DumpParms("target intent:");
          LOG4CPLUS_FATAL(m_logger, msg);
          throw LoadError(msg);
       }
    } else {
       if (ownship_aircraft_intent.GetNumberOfWaypoints() != 2) {
          const string msg = "For FAS, The on-final ownship intent is not 2. It must be malformed.";
-         ownship_aircraft_intent.DumpParms("ownship intent:");
          LOG4CPLUS_FATAL(m_logger, msg);
          throw LoadError(msg);
       }
 
       if (m_target_aircraft_intent.GetNumberOfWaypoints() < 2) {
          const string msg = "For FAS, The on-vector target intent is too small. It must be malformed.";
-         m_target_aircraft_intent.DumpParms("target intent:");
          LOG4CPLUS_FATAL(m_logger, msg);
          throw LoadError(msg);
       }
@@ -275,7 +271,6 @@ bool IMClearance::ValidatePlannedTerminationPoint(const AircraftIntent &ownship_
       const string msg =
             "The planned termination point, " + m_planned_termination_point + ", was not found in the ownship intent.";
       LOG4CPLUS_FATAL(m_logger, msg);
-      ownship_aircraft_intent.DumpParms("Own Intent follows:");
       throw LoadError(msg);
    }
 
@@ -308,7 +303,6 @@ bool IMClearance::ValidateTrafficReferencePoint(const AircraftIntent &ownship_ai
             std::string msg = "The Traffic-Reference-Point has not been found in the target intent. Looked for " +
                               m_traffic_reference_point + ".";
             LOG4CPLUS_FATAL(m_logger, msg);
-            m_target_aircraft_intent.DumpParms("Target Intent");
             throw LoadError(msg);
          }
       }

--- a/IntervalManagement/IMClearanceLoader.cpp
+++ b/IntervalManagement/IMClearanceLoader.cpp
@@ -124,7 +124,6 @@ const IMClearance IMClearanceLoader::BuildClearance(void) {
    if (!m_loaded) return m_empty_clearance;
 
    if (m_target_aircraft_intent_loader.IsLoaded()) {
-      m_target_aircraft_intent_loader.GetAircraftIntent().SetId(m_target_id);
    }
 
    IMClearance::Builder builder(m_clearance_type, m_target_id, m_target_aircraft_intent_loader.GetAircraftIntent(),

--- a/IntervalManagement/IMDistBasedAchieve.cpp
+++ b/IntervalManagement/IMDistBasedAchieve.cpp
@@ -119,11 +119,11 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
 
       if (m_target_reference_lookup_index == -1) {
          m_target_reference_lookup_index =
-               static_cast<int>(m_target_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1);
+               static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
          m_ownship_reference_lookup_index =
-               static_cast<int>(m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1);
+               static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
          m_reference_precalc_index =
-               static_cast<int>(m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1);
+               static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
       }
 
       if (InAchieveStage()) {
@@ -140,21 +140,20 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
          Units::Time target_reference_ttg_to_trp = Units::zero();
 
          m_target_reference_lookup_index =
-               CoreUtils::FindNearestIndex(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-                                           m_target_kinematic_trajectory_predictor.GetVerticalPathDistances());
+               mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).resolved_index;
 
          if (m_target_reference_lookup_index >=
-             m_target_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1) {
+             mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1) {
             target_reference_ttg_to_ptp =
-                  Units::SecondsTime(m_target_kinematic_trajectory_predictor.GetVerticalPathTimes().back());
+                  Units::SecondsTime(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).time_to_go);
             m_target_reference_lookup_index =
-                  static_cast<int>(m_target_kinematic_trajectory_predictor.GetVerticalPathTimes().size() - 1);
+                  static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
             m_target_reference_altitude =
-                  Units::MetersLength(m_target_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back());
+                  Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl);
             m_target_reference_gs = Units::MetersPerSecondSpeed(
-                  m_target_kinematic_trajectory_predictor.GetVerticalPathGroundspeeds().back());
+                  mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).ground_speed);
             m_target_reference_ias = Units::MetersPerSecondSpeed(
-                  m_target_kinematic_trajectory_predictor.GetVerticalPathVelocities().back());
+                  mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed);
          } else if (m_target_reference_lookup_index == 0) {
             target_reference_ttg_to_ptp =
                   mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).time_to_go;
@@ -163,22 +162,10 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
             m_target_reference_gs = Units::ZERO_SPEED;
             m_target_reference_ias = Units::ZERO_SPEED;
          } else {
-            target_reference_ttg_to_ptp = Units::SecondsTime(CoreUtils::LinearlyInterpolate(
-                  m_target_reference_lookup_index, Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-                  m_target_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-                  m_target_kinematic_trajectory_predictor.GetVerticalPathTimes()));
-            m_target_reference_altitude = Units::MetersLength(CoreUtils::LinearlyInterpolate(
-                  m_target_reference_lookup_index, Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-                  m_target_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-                  m_target_kinematic_trajectory_predictor.GetVerticalPathAltitudes()));
-            m_target_reference_gs = Units::MetersPerSecondSpeed(CoreUtils::LinearlyInterpolate(
-                  m_target_reference_lookup_index, Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-                  m_target_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-                  m_target_kinematic_trajectory_predictor.GetVerticalPathGroundspeeds()));
-            m_target_reference_ias = Units::MetersPerSecondSpeed(CoreUtils::LinearlyInterpolate(
-                  m_target_reference_lookup_index, Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-                  m_target_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-                  m_target_kinematic_trajectory_predictor.GetVerticalPathVelocities()));
+            target_reference_ttg_to_ptp = Units::SecondsTime(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).time_to_go);
+            m_target_reference_altitude = Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).altitude_msl);
+            m_target_reference_gs = Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).ground_speed);
+            m_target_reference_ias = Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).calibrated_airspeed);
          }
 
          target_reference_ttg_to_trp =
@@ -189,17 +176,17 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
          if (m_previous_im_speed_command_ias == Units::zero()) {
             m_previous_reference_im_speed_command_tas = m_weather_prediction.getAtmosphere()->CAS2TAS(
                   Units::MetersPerSecondSpeed(
-                        m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back()),
-                  Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back()));
+                        mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed),
+                  Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl));
 
             m_previous_im_speed_command_ias = Units::MetersPerSecondSpeed(
-                  m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back());
+                  mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed);
             m_previous_reference_im_speed_command_mach =
                   Units::MetersPerSecondSpeed(m_previous_reference_im_speed_command_tas).value() /
                   sqrt(kGamma * R.value() *
                        m_weather_prediction.getAtmosphere()
                              ->GetTemperature(Units::MetersLength(
-                                   m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back()))
+                                   mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl))
                              .value());
          }
 
@@ -207,38 +194,31 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
          Units::MetersLength ownship_reference_distance =
                m_ownship_kinematic_achieve_by_calcs.GetDistanceFromWaypoint() + m_assigned_spacing_goal;
 
-         m_ownship_reference_lookup_index = CoreUtils::FindNearestIndex(
-               ownship_reference_distance.value(), m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
+         m_ownship_reference_lookup_index = mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(ownship_reference_distance.value())).resolved_index;
 
          // Note that this calculation includes the ASG. Be careful how used.
          ownship_ttg_from_abp_to_ptp = Units::SecondsTime(
-               CoreUtils::LinearlyInterpolate(m_ownship_reference_lookup_index, ownship_reference_distance.value(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes()));
+               mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(ownship_reference_distance.value())).time_to_go);
 
          if (m_ownship_kinematic_dtg_to_ptp <=
              Units::abs(
-                   Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().back()))) {
+                   Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).along_path_distance))) {
             m_ownship_reference_lookup_index =
-                  CoreUtils::FindNearestIndex(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
+                  mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).resolved_index;
 
             if (m_ownship_reference_lookup_index >=
-                m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1) {
+                mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1) {
                m_ownship_reference_ttg_to_ptp =
-                     Units::SecondsTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes().back());
+                     Units::SecondsTime(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).time_to_go);
                m_ownship_ttg_to_abp = m_ownship_reference_ttg_to_ptp - ownship_ttg_from_abp_to_ptp;
                m_ownship_reference_lookup_index =
-                     static_cast<int>(m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes().size() - 1);
+                     static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
             } else if (m_ownship_reference_lookup_index == 0) {
                m_ownship_reference_ttg_to_ptp =
                      mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).time_to_go;
                m_ownship_ttg_to_abp = m_ownship_reference_ttg_to_ptp - ownship_ttg_from_abp_to_ptp;
             } else {
-               m_ownship_reference_ttg_to_ptp = Units::SecondsTime(CoreUtils::LinearlyInterpolate(
-                     m_ownship_reference_lookup_index, Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-                     m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-                     m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes()));
+               m_ownship_reference_ttg_to_ptp = Units::SecondsTime(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).time_to_go);
                m_ownship_ttg_to_abp = m_ownship_reference_ttg_to_ptp - ownship_ttg_from_abp_to_ptp;
             }
          }
@@ -264,21 +244,20 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
          Units::Time ownrefttgtoend = reference_ttg + ownship_ttg_from_abp_to_ptp;
 
          m_reference_precalc_index =
-               CoreUtils::FindNearestIndex(Units::SecondsTime(ownrefttgtoend).value(),
-                                           m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes());
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).resolved_index;
 
-         if (m_reference_precalc_index >= m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes().size() - 1) {
+         if (m_reference_precalc_index >= mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1) {
             m_reference_precalc_index =
-                  static_cast<int>(m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes().size() - 1);
+                  static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
 
             ownship_reference_dtg_to_ptp =
-                  Units::MetersLength(-m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().back());
+                  Units::MetersLength(-mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).along_path_distance);
             m_ownship_reference_cas = Units::MetersPerSecondSpeed(
-                  m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back());
+                  mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed);
             m_ownship_reference_gs = Units::MetersPerSecondSpeed(
-                  m_ownship_kinematic_trajectory_predictor.GetVerticalPathGroundspeeds().back());
+                  mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).ground_speed);
             m_ownship_reference_altitude =
-                  Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back());
+                  Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl);
          } else if (m_reference_precalc_index == 0) {
             ownship_reference_dtg_to_ptp =
                   -mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).along_path_distance;
@@ -289,22 +268,13 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
                   mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).altitude_msl;
          } else {
             ownship_reference_dtg_to_ptp = Units::MetersLength(
-                  -CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                                                  m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                                  m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances()));
+                  -mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).along_path_distance);
 
             m_ownship_reference_cas = Units::MetersPerSecondSpeed(
-                  CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                                                 m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                                 m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities()));
-            m_ownship_reference_gs = Units::MetersPerSecondSpeed(CoreUtils::LinearlyInterpolate(
-                  m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                  m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                  m_ownship_kinematic_trajectory_predictor.GetVerticalPathGroundspeeds()));
+                  mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).calibrated_airspeed);
+            m_ownship_reference_gs = Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).ground_speed);
             m_ownship_reference_altitude = Units::MetersLength(
-                  CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                                                 m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                                 m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes()));
+                  mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).altitude_msl);
          }
 
          m_im_speed_command_ias =
@@ -480,8 +450,7 @@ void IMDistBasedAchieve::CalculateIas(const Units::Length current_ownship_altitu
       m_predicted_spacing_interval = Units::NegInfinity();
 
       m_ownship_reference_lookup_index =
-            CoreUtils::FindNearestIndex(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-                                        m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
+            mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).resolved_index;
 
       Units::Speed nominal_profile_ias = Units::MetersPerSecondSpeed(
             mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed);
@@ -548,8 +517,7 @@ void IMDistBasedAchieve::CalculateMach(const Units::Time reference_ttg, const Un
       m_predicted_spacing_interval = Units::NegInfinity();
 
       m_ownship_reference_lookup_index =
-            CoreUtils::FindNearestIndex(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-                                        m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
+            mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).resolved_index;
 
       Units::MetersPerSecondSpeed nominal_indicated_airspeed(
             mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed);
@@ -637,14 +605,7 @@ void IMDistBasedAchieve::RecordData(mitre::oss::simcore::Guidance &im_guidance,
 
 const Units::MetersLength IMDistBasedAchieve::CalculatePredictedSpacingInterval(
       const Units::Time target_reference_ttg_to_trp) {
-   const auto ownship_reference_dtg_to_ptp_index =
-         CoreUtils::FindNearestIndex(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-                                     m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
-
-   const Units::Time own_ttg_to_ptp = Units::SecondsTime(CoreUtils::LinearlyInterpolate(
-         ownship_reference_dtg_to_ptp_index, Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-         m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-         m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes()));
+   const Units::Time own_ttg_to_ptp = Units::SecondsTime(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).time_to_go);
 
    const Units::Time ownship_kinematic_ttg_to_abp =
          own_ttg_to_ptp - m_ownship_kinematic_achieve_by_calcs.GetTimeToGoToWaypoint();
@@ -652,14 +613,15 @@ const Units::MetersLength IMDistBasedAchieve::CalculatePredictedSpacingInterval(
    const Units::SecondsTime predicted_spacing_interval_lookup_ttg =
          ownship_target_delta_ttg + m_ownship_kinematic_achieve_by_calcs.GetTimeToGoToWaypoint();
    const Units::Length ownship_dtg_from_abp_to_ptp = m_ownship_kinematic_achieve_by_calcs.GetDistanceFromWaypoint();
-   const auto index_ttg = CoreUtils::FindNearestIndex(predicted_spacing_interval_lookup_ttg.value(),
-                                                      m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes());
+   const auto index_ttg = mitre::oss::simcore::VerticalPathUtils::GetPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(predicted_spacing_interval_lookup_ttg.value())).resolved_index;
 
    if ((ownship_target_delta_ttg < Units::zero()) && (index_ttg == 0)) {
       // This calculation handles negative PSI situations in which there is no maintain stage afterward. In this
       // situation, the PSI must be guessed using ownship's predicted groundspeed.
       const Units::Speed ownship_groundspeed_at_ptp =
-            Units::MetersPerSecondSpeed(m_ownship_kinematic_trajectory_predictor.GetVerticalPathGroundspeeds().front());
+            mitre::oss::simcore::VerticalPathUtils::GetFirstPathData(
+                  m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath())
+                  .ground_speed;
       const Units::Time ownship_time_past_ptp = target_reference_ttg_to_trp - own_ttg_to_ptp;
       const Units::Length ownship_distance_passed_abp =
             ownship_groundspeed_at_ptp * ownship_time_past_ptp + ownship_dtg_from_abp_to_ptp;
@@ -672,9 +634,7 @@ const Units::MetersLength IMDistBasedAchieve::CalculatePredictedSpacingInterval(
       // ** positive PSI situations
       // ** negative PSI situations in which there is a valid 4D prediction that goes beyond the ABP
       const Units::Length ownship_reference_dtg_at_predicted_spacing_interval_lookup_distance = Units::MetersLength(
-            CoreUtils::LinearlyInterpolate(index_ttg, predicted_spacing_interval_lookup_ttg.value(),
-                                           m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                           m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances()));
+            mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(predicted_spacing_interval_lookup_ttg.value())).along_path_distance);
 
       const Units::Length predicted_spacing_interval =
             ownship_reference_dtg_at_predicted_spacing_interval_lookup_distance - ownship_dtg_from_abp_to_ptp;

--- a/IntervalManagement/IMDistBasedAchieve.cpp
+++ b/IntervalManagement/IMDistBasedAchieve.cpp
@@ -157,9 +157,9 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
                   m_target_kinematic_trajectory_predictor.GetVerticalPathVelocities().back());
          } else if (m_target_reference_lookup_index == 0) {
             target_reference_ttg_to_ptp =
-                  Units::SecondsTime(m_target_kinematic_trajectory_predictor.GetVerticalPathTimeByIndex(0));
+                  mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).time_to_go;
             m_target_reference_altitude =
-                  Units::MetersLength(m_target_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
+                  mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).altitude_msl;
             m_target_reference_gs = Units::ZERO_SPEED;
             m_target_reference_ias = Units::ZERO_SPEED;
          } else {
@@ -232,7 +232,7 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
                      static_cast<int>(m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes().size() - 1);
             } else if (m_ownship_reference_lookup_index == 0) {
                m_ownship_reference_ttg_to_ptp =
-                     Units::SecondsTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimeByIndex(0));
+                     mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).time_to_go;
                m_ownship_ttg_to_abp = m_ownship_reference_ttg_to_ptp - ownship_ttg_from_abp_to_ptp;
             } else {
                m_ownship_reference_ttg_to_ptp = Units::SecondsTime(CoreUtils::LinearlyInterpolate(
@@ -281,12 +281,12 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
                   Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back());
          } else if (m_reference_precalc_index == 0) {
             ownship_reference_dtg_to_ptp =
-                  Units::MetersLength(-m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistanceByIndex(0));
+                  -mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).along_path_distance;
             m_ownship_reference_cas = Units::MetersPerSecondSpeed(
                   mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).calibrated_airspeed);
             m_ownship_reference_gs = Units::ZERO_SPEED;
             m_ownship_reference_altitude =
-                  Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
+                  mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).altitude_msl;
          } else {
             ownship_reference_dtg_to_ptp = Units::MetersLength(
                   -CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
@@ -473,7 +473,7 @@ void IMDistBasedAchieve::CalculateIas(const Units::Length current_ownship_altitu
    if (!IsTargetPassedTrp()) {
       m_im_speed_command_ias = m_speed_limiter.LimitSpeedCommand(
             m_previous_im_speed_command_ias, m_im_speed_command_ias,
-            m_ownship_kinematic_trajectory_predictor.GetVerticalPathCasByIndex(m_ownship_reference_lookup_index),
+            mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed,
             m_ownship_kinematic_dtg_to_abp, m_ownship_kinematic_dtg_to_ptp, current_ownship_altitude,
             three_dof_dynamics_state.flap_configuration);
    } else {
@@ -488,7 +488,7 @@ void IMDistBasedAchieve::CalculateIas(const Units::Length current_ownship_altitu
 
       m_im_speed_command_ias = m_speed_limiter.LimitSpeedCommand(
             m_previous_im_speed_command_ias, Units::min(nominal_profile_ias, m_previous_im_speed_command_ias),
-            m_ownship_kinematic_trajectory_predictor.GetVerticalPathCasByIndex(m_ownship_reference_lookup_index),
+            mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed,
             m_ownship_kinematic_dtg_to_abp, m_ownship_kinematic_dtg_to_ptp, current_ownship_altitude,
             three_dof_dynamics_state.flap_configuration);
    }

--- a/IntervalManagement/IMDistBasedAchieve.cpp
+++ b/IntervalManagement/IMDistBasedAchieve.cpp
@@ -29,7 +29,7 @@
 #include "public/SimulationTime.h"
 
 using namespace interval_management::open_source;
-using namespace aaesim::open_source;
+using namespace mitre::oss::simcore;
 
 log4cplus::Logger IMDistBasedAchieve::m_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("IMDistBasedAchieve"));
 const Units::Length IMDistBasedAchieve::DEFAULT_DISTANCE_BASED_ASSIGNED_SPACING_GOAL = Units::NegInfinity();
@@ -56,7 +56,7 @@ IMDistBasedAchieve::~IMDistBasedAchieve() = default;
 
 void IMDistBasedAchieve::Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                                     const AircraftIntent &ownship_aircraft_intent,
-                                    aaesim::open_source::WeatherPrediction &weather_prediction,
+                                    mitre::oss::simcore::WeatherPrediction &weather_prediction,
                                     std::shared_ptr<TangentPlaneSequence> &position_converter) {
    SetTangentPlaneSequence(position_converter);
    Initialize(ownship_prediction_parameters, ownship_aircraft_intent, weather_prediction);
@@ -64,7 +64,7 @@ void IMDistBasedAchieve::Initialize(const OwnshipPredictionParameters &ownship_p
 
 void IMDistBasedAchieve::Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                                     const AircraftIntent &ownship_aircraft_intent,
-                                    aaesim::open_source::WeatherPrediction &weather_prediction) {
+                                    mitre::oss::simcore::WeatherPrediction &weather_prediction) {
    IMKinematicAchieve::Initialize(ownship_prediction_parameters, ownship_aircraft_intent, weather_prediction);
 
    m_im_kinematic_dist_based_maintain->SetQuantizeFlag(GetQuantizeFlag());
@@ -98,13 +98,13 @@ bool IMDistBasedAchieve::load(DecodedStream *input) {
    return loaded;
 }
 
-aaesim::open_source::Guidance IMDistBasedAchieve::Update(
-      const aaesim::open_source::Guidance &previous_im_guidance,
-      const aaesim::open_source::DynamicsState &three_dof_dynamics_state,
+mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
+      const mitre::oss::simcore::Guidance &previous_im_guidance,
+      const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state,
       const interval_management::open_source::AircraftState &current_ownship_state,
       const interval_management::open_source::AircraftState &current_target_state,
       const vector<interval_management::open_source::AircraftState> &target_adsb_history) {
-   aaesim::open_source::Guidance im_guidance =
+   mitre::oss::simcore::Guidance im_guidance =
          IMKinematicAchieve::Update(previous_im_guidance, three_dof_dynamics_state, current_ownship_state,
                                     current_target_state, target_adsb_history);
 
@@ -468,7 +468,7 @@ aaesim::open_source::Guidance IMDistBasedAchieve::Update(
 }
 
 void IMDistBasedAchieve::CalculateIas(const Units::Length current_ownship_altitude,
-                                      const aaesim::open_source::DynamicsState &three_dof_dynamics_state) {
+                                      const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state) {
    if (!IsTargetPassedTrp()) {
       m_im_speed_command_ias = m_speed_limiter.LimitSpeedCommand(
             m_previous_im_speed_command_ias, m_im_speed_command_ias,
@@ -577,10 +577,10 @@ void IMDistBasedAchieve::CalculateMach(const Units::Time reference_ttg, const Un
    m_previous_reference_im_speed_command_mach = estimated_mach;
 }
 
-void IMDistBasedAchieve::RecordData(aaesim::open_source::Guidance &im_guidance,
+void IMDistBasedAchieve::RecordData(mitre::oss::simcore::Guidance &im_guidance,
                                     const interval_management::open_source::AircraftState &current_ownship_state,
                                     const interval_management::open_source::AircraftState &current_target_state,
-                                    const aaesim::open_source::DynamicsState &three_dof_dynamics_state,
+                                    const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state,
                                     Units::Speed unmodified_im_speed_command_ias, Units::Speed im_speed_command_tas,
                                     Units::Speed ownship_reference_cas, Units::Length ownship_reference_dtg_to_ptp,
                                     Units::Time target_reference_ttg_to_trp) {

--- a/IntervalManagement/IMDistBasedAchieve.cpp
+++ b/IntervalManagement/IMDistBasedAchieve.cpp
@@ -27,6 +27,7 @@
 #include "public/CoreUtils.h"
 #include "public/CustomMath.h"
 #include "public/SimulationTime.h"
+#include "public/VerticalPathUtils.h"
 
 using namespace interval_management::open_source;
 using namespace mitre::oss::simcore;
@@ -282,7 +283,7 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
             ownship_reference_dtg_to_ptp =
                   Units::MetersLength(-m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistanceByIndex(0));
             m_ownship_reference_cas = Units::MetersPerSecondSpeed(
-                  m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(0));
+                  mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).calibrated_airspeed);
             m_ownship_reference_gs = Units::ZERO_SPEED;
             m_ownship_reference_altitude =
                   Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
@@ -483,7 +484,7 @@ void IMDistBasedAchieve::CalculateIas(const Units::Length current_ownship_altitu
                                         m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
 
       Units::Speed nominal_profile_ias = Units::MetersPerSecondSpeed(
-            m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(m_ownship_reference_lookup_index));
+            mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed);
 
       m_im_speed_command_ias = m_speed_limiter.LimitSpeedCommand(
             m_previous_im_speed_command_ias, Units::min(nominal_profile_ias, m_previous_im_speed_command_ias),
@@ -525,8 +526,8 @@ void IMDistBasedAchieve::CalculateMach(const Units::Time reference_ttg, const Un
 
          // Make sure velocity is within nominal limits (AAES-694)
          Units::MetersPerSecondSpeed nominal_indicated_airspeed(
-               m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(
-                     m_ownship_reference_lookup_index));
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(),
+                     m_ownship_reference_lookup_index).calibrated_airspeed);
          Units::Speed nominal_true_airspeed =
                m_weather_prediction.getAtmosphere()->CAS2TAS(nominal_indicated_airspeed, current_ownship_altitude);
          BoundedValue<double, 0, 2> nominal_mach =
@@ -551,7 +552,7 @@ void IMDistBasedAchieve::CalculateMach(const Units::Time reference_ttg, const Un
                                         m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
 
       Units::MetersPerSecondSpeed nominal_indicated_airspeed(
-            m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(m_ownship_reference_lookup_index));
+            mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed);
       Units::Speed nominal_true_airspeed =
             m_weather_prediction.getAtmosphere()->CAS2TAS(nominal_indicated_airspeed, current_ownship_altitude);
       double nominal_mach = Units::MetersPerSecondSpeed(nominal_true_airspeed).value() /
@@ -596,12 +597,14 @@ void IMDistBasedAchieve::RecordData(mitre::oss::simcore::Guidance &im_guidance,
       if (m_ownship_kinematic_dtg_to_ptp <= Units::NauticalMilesLength(nm_observer.curr_NM) && im_guidance.IsValid()) {
          nm_observer.curr_NM--;
 
-         double minimum_allowable_reference_im_speed_cas =
-               m_speed_limiter.LowLimit(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(
-                     m_ownship_reference_lookup_index));
-         double maximum_allowable_reference_im_speed_cas =
-               m_speed_limiter.HighLimit(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(
-                     m_ownship_reference_lookup_index));
+         double minimum_allowable_reference_im_speed_cas = Units::MetersPerSecondSpeed(
+               m_speed_limiter.LowLimit(mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(
+                     m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(),
+                     m_ownship_reference_lookup_index).calibrated_airspeed)).value();
+         double maximum_allowable_reference_im_speed_cas = Units::MetersPerSecondSpeed(
+               m_speed_limiter.HighLimit(mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(
+                     m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(),
+                     m_ownship_reference_lookup_index).calibrated_airspeed)).value();
 
          double minimum_allowable_reference_im_speed_tas =
                Units::MetersPerSecondSpeed(m_weather_prediction.getAtmosphere()->CAS2TAS(

--- a/IntervalManagement/IMDistBasedAchieve.cpp
+++ b/IntervalManagement/IMDistBasedAchieve.cpp
@@ -283,7 +283,7 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
 
          m_unmodified_im_speed_command_ias = m_im_speed_command_ias;
 
-         if (im_guidance.GetSelectedSpeed().GetSpeedType() == INDICATED_AIR_SPEED) {
+         if (im_guidance.GetSelectedSpeedType() == INDICATED_AIR_SPEED) {
             CalculateIas(current_ownship_state.GetPositionZ(), three_dof_dynamics_state);
          } else {
             CalculateMach(reference_ttg, current_ownship_state.GetPositionZ(), three_dof_dynamics_state.current_mass);
@@ -300,7 +300,7 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
 
          if (m_pilot_delay.IsPilotDelayOn()) {
             im_guidance.m_ias_command = m_im_speed_command_with_pilot_delay;
-            if (im_guidance.GetSelectedSpeed().GetSpeedType() == MACH_SPEED) {
+            if (im_guidance.GetSelectedSpeedType() == MACH_SPEED) {
                const auto true_airspeed_equivalent = m_weather_prediction.CAS2TAS(m_im_speed_command_with_pilot_delay,
                                                                                   current_ownship_state.GetPositionZ());
                const auto mach_equivalent =
@@ -309,7 +309,7 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
             }
          } else {
             im_guidance.m_ias_command = m_im_speed_command_ias;
-            if (im_guidance.GetSelectedSpeed().GetSpeedType() == MACH_SPEED) {
+            if (im_guidance.GetSelectedSpeedType() == MACH_SPEED) {
                const auto true_airspeed_equivalent =
                      m_weather_prediction.CAS2TAS(m_im_speed_command_ias, current_ownship_state.GetPositionZ());
                const auto mach_equivalent =
@@ -348,7 +348,7 @@ mitre::oss::simcore::Guidance IMDistBasedAchieve::Update(
          if (m_distance_calculator_target_on_ownship_hpath.IsPassedEndOfRoute() || !m_target_aircraft_exists) {
             // Operation is completing. IM Speed must be defaulted; the control law cannot be used.
             m_measured_spacing_interval = Units::NegInfinity();
-            if (im_guidance.GetSelectedSpeed().GetSpeedType() == INDICATED_AIR_SPEED) {
+            if (im_guidance.GetSelectedSpeedType() == INDICATED_AIR_SPEED) {
                CalculateIas(current_ownship_state.GetPositionZ(), three_dof_dynamics_state);
             } else {
                CalculateMach(Units::negInfinity(), current_ownship_state.GetPositionZ(),

--- a/IntervalManagement/IMKinematicAchieve.cpp
+++ b/IntervalManagement/IMKinematicAchieve.cpp
@@ -36,7 +36,7 @@
 #include "public/Wind.h"
 
 using namespace interval_management::open_source;
-using namespace aaesim::open_source;
+using namespace mitre::oss::simcore;
 
 log4cplus::Logger IMKinematicAchieve::logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("IMKinematicAchieve"));
 const int IMKinematicAchieve::MINIMUM_FAS_TRACK_COUNT(5);
@@ -83,7 +83,7 @@ void IMKinematicAchieve::IterClearIMKinAch() {
    m_target_aircraft_exists = false;
    m_target_history_exists = false;
 
-   aaesim::open_source::KinematicTrajectoryPredictor dummytraj;
+   mitre::oss::simcore::KinematicTrajectoryPredictor dummytraj;
 
    m_ownship_kinematic_trajectory_predictor = dummytraj;
    m_target_kinematic_trajectory_predictor = dummytraj;
@@ -97,7 +97,7 @@ void IMKinematicAchieve::IterClearIMKinAch() {
 
 void IMKinematicAchieve::Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                                     const AircraftIntent &ownship_aircraft_intent,
-                                    aaesim::open_source::WeatherPrediction &weather_prediction) {
+                                    mitre::oss::simcore::WeatherPrediction &weather_prediction) {
    IMAchieve::Initialize(ownship_prediction_parameters, ownship_aircraft_intent, weather_prediction);
 
    m_ownship_track_angle_history.clear();
@@ -117,7 +117,7 @@ void IMKinematicAchieve::Initialize(const OwnshipPredictionParameters &ownship_p
    m_ownship_aircraft_intent = FIMAircraftIntent::Builder(ownship_aircraft_intent).Build();
 
    // Create the kinematic trajectory predictors using ownship assumptions
-   m_ownship_kinematic_trajectory_predictor = aaesim::open_source::KinematicTrajectoryPredictor(
+   m_ownship_kinematic_trajectory_predictor = mitre::oss::simcore::KinematicTrajectoryPredictor(
          ownship_prediction_parameters.maximum_allowable_bank_angle, ownship_prediction_parameters.transition_ias,
          ownship_prediction_parameters.transition_mach, ownship_prediction_parameters.transition_altitude,
          ownship_prediction_parameters.expected_cruise_altitude);
@@ -140,7 +140,7 @@ void IMKinematicAchieve::Initialize(const OwnshipPredictionParameters &ownship_p
          TrajectoryIndexProgressionDirection::UNDEFINED);
 
    // --- Prepare Target objects -------------
-   m_target_kinematic_trajectory_predictor = aaesim::open_source::KinematicTrajectoryPredictor(
+   m_target_kinematic_trajectory_predictor = mitre::oss::simcore::KinematicTrajectoryPredictor(
          ownship_prediction_parameters.maximum_allowable_bank_angle, ownship_prediction_parameters.transition_ias,
          ownship_prediction_parameters.transition_mach, ownship_prediction_parameters.transition_altitude,
          ownship_prediction_parameters.expected_cruise_altitude);
@@ -177,12 +177,12 @@ bool IMKinematicAchieve::load(DecodedStream *input) {
    return m_loaded;
 }
 
-aaesim::open_source::Guidance IMKinematicAchieve::Update(
-      const aaesim::open_source::Guidance &prevguidance, const aaesim::open_source::DynamicsState &dynamicsstate,
+mitre::oss::simcore::Guidance IMKinematicAchieve::Update(
+      const mitre::oss::simcore::Guidance &prevguidance, const mitre::oss::simcore::DynamicsState &dynamicsstate,
       const interval_management::open_source::AircraftState &owntruthstate,
       const interval_management::open_source::AircraftState &targetsyncstate,
       const vector<interval_management::open_source::AircraftState> &targethistory) {
-   aaesim::open_source::Guidance guidance_out =
+   mitre::oss::simcore::Guidance guidance_out =
          IMAchieve::Update(prevguidance, dynamicsstate, owntruthstate, targetsyncstate, targethistory);
 
    m_ownship_aircraft_intent = FIMAircraftIntent::Builder(m_ownship_aircraft_intent)
@@ -272,7 +272,7 @@ void IMKinematicAchieve::HandleTrajectoryPrediction(
                                                                          Units::FeetLength(owntruthstate.m_z),
                                                                          ownship_distance_to_go);
 
-      std::shared_ptr<aaesim::open_source::KinematicDescent4DPredictor> kinematic_descent_4d_predictor =
+      std::shared_ptr<mitre::oss::simcore::KinematicDescent4DPredictor> kinematic_descent_4d_predictor =
             m_ownship_kinematic_trajectory_predictor.GetKinematicDescent4dPredictor();
       CalculateRFLegPhase(m_ownship_kinematic_trajectory_predictor.GetPrecalcWaypoints(),
                           Units::MetersSecondAcceleration(kinematic_descent_4d_predictor->GetDecelerationRateFPA()),
@@ -864,7 +864,7 @@ void IMKinematicAchieve::ComputeFASTrajectories(
    // randomize merge angle around the mean
    Units::Angle merge_angle_std = m_im_clearance.GetFinalApproachSpacingMergeAngleStd();
    Units::Angle merge_angle =
-         aaesim::open_source::ScenarioUtils::RANDOM_NUMBER_GENERATOR.GaussianSample(merge_angle_mean, merge_angle_std);
+         mitre::oss::simcore::ScenarioUtils::RANDOM_NUMBER_GENERATOR.GaussianSample(merge_angle_mean, merge_angle_std);
    Units::DegreesAngle final_approach_angle = reverse_final_approach_angle + Units::PI_RADIANS_ANGLE;
    LOG4CPLUS_TRACE(logger, "Average track angle = " << Units::DegreesAngle(merge_angle_mean)
                                                     << ", randomized merge angle = " << Units::DegreesAngle(merge_angle)

--- a/IntervalManagement/IMKinematicAchieve.cpp
+++ b/IntervalManagement/IMKinematicAchieve.cpp
@@ -34,6 +34,7 @@
 #include "public/Environment.h"
 #include "public/ScenarioUtils.h"
 #include "public/Wind.h"
+#include "public/VerticalPathUtils.h"
 
 using namespace interval_management::open_source;
 using namespace mitre::oss::simcore;
@@ -454,7 +455,7 @@ void IMKinematicAchieve::CheckPredictionAccuracy(
       } else if (ownship_reference_index == 0) {
          // beginning
          m_ownship_reference_cas =
-               Units::MetersPerSecondSpeed(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(0));
+               Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).calibrated_airspeed);
          m_ownship_reference_altitude =
                Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
       } else {
@@ -1055,7 +1056,7 @@ void IMKinematicAchieve::SetTrafficReferencePointConstraints(
       } else if (ownship_achieve_by_index == 0) {
          // beginning
          ownship_cas_at_abp =
-               Units::MetersPerSecondSpeed(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(0));
+               Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).calibrated_airspeed);
          ownship_altitude_at_abp =
                Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
       } else {

--- a/IntervalManagement/IMKinematicAchieve.cpp
+++ b/IntervalManagement/IMKinematicAchieve.cpp
@@ -457,7 +457,7 @@ void IMKinematicAchieve::CheckPredictionAccuracy(
          m_ownship_reference_cas =
                Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).calibrated_airspeed);
          m_ownship_reference_altitude =
-               Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).altitude_msl;
       } else {
          // normal case, middle somewhere, so interpolate
          m_ownship_reference_cas = Units::MetersPerSecondSpeed(CoreUtils::LinearlyInterpolate(
@@ -504,7 +504,7 @@ void IMKinematicAchieve::CheckPredictionAccuracy(
       } else if (target_reference_index == 0) {
          // beginning
          m_target_reference_altitude =
-               Units::MetersLength(m_target_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).altitude_msl;
       } else {
          // normal case, middle somewhere, so interpolate
          m_target_reference_altitude = Units::MetersLength(CoreUtils::LinearlyInterpolate(
@@ -1058,7 +1058,7 @@ void IMKinematicAchieve::SetTrafficReferencePointConstraints(
          ownship_cas_at_abp =
                Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).calibrated_airspeed);
          ownship_altitude_at_abp =
-               Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).altitude_msl;
       } else {
          // normal case, middle somewhere, so interpolate
          ownship_cas_at_abp = Units::MetersPerSecondSpeed(

--- a/IntervalManagement/IMKinematicAchieve.cpp
+++ b/IntervalManagement/IMKinematicAchieve.cpp
@@ -397,8 +397,17 @@ void IMKinematicAchieve::HandleTrajectoryPrediction(
                                                .InsertWaypointAtIndex(m_traffic_reference_point, index).Build();
          } else {
             // retrieve TRP from target intent
-            const size_t trp_index(m_target_aircraft_intent.GetWaypointIndexByName(trp_name));
-            m_traffic_reference_point = m_target_aircraft_intent.GetWaypoint(trp_index);
+            const auto trp_index = m_target_aircraft_intent.GetWaypointIndexByName(trp_name);
+            if (!trp_index) {
+               throw std::runtime_error("Traffic reference point is not available in the target aircraft intent: " +
+                                        trp_name);
+            }
+            const auto traffic_reference_point = m_target_aircraft_intent.GetWaypoint(*trp_index);
+            if (!traffic_reference_point) {
+               throw std::runtime_error("Traffic reference point is not available in the target aircraft intent: " +
+                                        trp_name);
+            }
+            m_traffic_reference_point = *traffic_reference_point;
          }
 
          m_target_aircraft_intent = FIMAircraftIntent::CopyAndTrimAfterNamedWaypoint(m_target_aircraft_intent,
@@ -813,10 +822,18 @@ void IMKinematicAchieve::ComputeFASTrajectories(
    // find merge point
    Units::MetersLength x1, y1, x2, y2, x3, y3;  // point parameters
    string achieve_by_waypoint_name = m_im_clearance.GetAchieveByPoint();
-   int achieve_by_waypoint_index = m_ownship_aircraft_intent.GetWaypointIndexByName(achieve_by_waypoint_name);
+   const auto achieve_by_waypoint_index =
+         m_ownship_aircraft_intent.GetWaypointIndexByName(achieve_by_waypoint_name);
+   if (!achieve_by_waypoint_index) {
+      throw std::runtime_error("Achieve-by waypoint is not available in the ownship aircraft intent: " +
+                               achieve_by_waypoint_name);
+   }
 
    size_t target_end_waypoint_ix = m_target_aircraft_intent.GetNumberOfWaypoints() - 1;
-   Waypoint target_end_waypoint{m_target_aircraft_intent.GetWaypoint(target_end_waypoint_ix)};
+   const auto target_end_waypoint = m_target_aircraft_intent.GetWaypoint(target_end_waypoint_ix);
+   if (!target_end_waypoint) {
+      throw std::runtime_error("Target aircraft intent has no final waypoint");
+   }
 
    LOG4CPLUS_TRACE(logger, "Achieve by = " << achieve_by_waypoint_name);
 
@@ -824,8 +841,8 @@ void IMKinematicAchieve::ComputeFASTrajectories(
    Units::MetersLength delta_y, delta_x;
    if (m_im_clearance.IsVectorAircraft()) {
       merge_angle_mean = IMUtils::CalculateTrackAngle(m_ownship_track_angle_history);
-      x2 = m_ownship_aircraft_intent.GetWaypointX(achieve_by_waypoint_index);
-      y2 = m_ownship_aircraft_intent.GetWaypointY(achieve_by_waypoint_index);
+      x2 = m_ownship_aircraft_intent.GetWaypointX(*achieve_by_waypoint_index);
+      y2 = m_ownship_aircraft_intent.GetWaypointY(*achieve_by_waypoint_index);
       x3 = owntruthstate.GetPositionX();
       y3 = owntruthstate.GetPositionY();
       delta_x = targettruthstate.GetPositionX() - m_target_aircraft_intent.GetWaypointX(target_end_waypoint_ix);
@@ -836,8 +853,8 @@ void IMKinematicAchieve::ComputeFASTrajectories(
       y2 = m_target_aircraft_intent.GetWaypointY(target_end_waypoint_ix);
       x3 = targettruthstate.GetPositionX();
       y3 = targettruthstate.GetPositionY();
-      delta_x = owntruthstate.GetPositionX() - m_ownship_aircraft_intent.GetWaypointX(achieve_by_waypoint_index);
-      delta_y = owntruthstate.GetPositionY() - m_ownship_aircraft_intent.GetWaypointY(achieve_by_waypoint_index);
+      delta_x = owntruthstate.GetPositionX() - m_ownship_aircraft_intent.GetWaypointX(*achieve_by_waypoint_index);
+      delta_y = owntruthstate.GetPositionY() - m_ownship_aircraft_intent.GetWaypointY(*achieve_by_waypoint_index);
    }
    Units::DegreesAngle reverse_final_approach_angle = Units::arctan2(delta_y.value(), delta_x.value());
    LOG4CPLUS_TRACE(logger, reverse_final_approach_angle);
@@ -870,9 +887,12 @@ void IMKinematicAchieve::ComputeFASTrajectories(
                                       .ClearWaypoints()
                                       .SetPlannedCruiseAltitude(Units::FeetLength(targettruthstate.m_z));
 
-   Waypoint ptp_waypoint{m_ownship_aircraft_intent.GetWaypoint(achieve_by_waypoint_index)};
-   own_intent_builder.InsertWaypointAtIndex(ptp_waypoint, 0);
-   target_intent_builder.InsertWaypointAtIndex(target_end_waypoint, 0);
+   const auto ptp_waypoint = m_ownship_aircraft_intent.GetWaypoint(*achieve_by_waypoint_index);
+   if (!ptp_waypoint) {
+      throw std::runtime_error("Achieve-by waypoint is not available in the ownship aircraft intent");
+   }
+   own_intent_builder.InsertWaypointAtIndex(*ptp_waypoint, 0);
+   target_intent_builder.InsertWaypointAtIndex(*target_end_waypoint, 0);
 
    pair<Units::Length, Units::Length> final_wpt_coords(x2, y2);
    pair<Units::Length, Units::Length> merge_coords(xMerge, yMerge);

--- a/IntervalManagement/IMKinematicAchieve.cpp
+++ b/IntervalManagement/IMKinematicAchieve.cpp
@@ -878,13 +878,15 @@ void IMKinematicAchieve::ComputeFASTrajectories(
    // construct intents
    // final AC:  current_pos last_wp
    // vector AC:  current_pos merge_point last_wp
-   auto own_intent_builder = FIMAircraftIntent::Builder(m_ownship_aircraft_intent)
+   auto own_intent_builder = FIMAircraftIntent::Builder()
                                    .SetId(m_ownship_aircraft_intent.GetId())
-                                   .ClearWaypoints()
+                                   .SetPlannedCruiseMach(
+                                         BoundedValue<double, 0, 1>(m_ownship_aircraft_intent.GetPlannedCruiseMach()))
                                    .SetPlannedCruiseAltitude(Units::FeetLength(owntruthstate.m_z));
-   auto target_intent_builder = FIMAircraftIntent::Builder(m_target_aircraft_intent)
+   auto target_intent_builder = FIMAircraftIntent::Builder()
                                       .SetId(m_target_aircraft_intent.GetId())
-                                      .ClearWaypoints()
+                                      .SetPlannedCruiseMach(
+                                            BoundedValue<double, 0, 1>(m_target_aircraft_intent.GetPlannedCruiseMach()))
                                       .SetPlannedCruiseAltitude(Units::FeetLength(targettruthstate.m_z));
 
    const auto ptp_waypoint = m_ownship_aircraft_intent.GetWaypoint(*achieve_by_waypoint_index);

--- a/IntervalManagement/IMKinematicAchieve.cpp
+++ b/IntervalManagement/IMKinematicAchieve.cpp
@@ -444,14 +444,13 @@ void IMKinematicAchieve::CheckPredictionAccuracy(
       CalculateOwnshipDtgToPlannedTerminationPoint(owntruthstate);
 
       int ownship_reference_index =
-            CoreUtils::FindNearestIndex(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-                                        m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
-      if (ownship_reference_index + 1 >= m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes().size()) {
+            mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).resolved_index;
+      if (ownship_reference_index + 1 >= mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath())) {
          // end
          m_ownship_reference_cas =
-               Units::MetersPerSecondSpeed(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back());
+               Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed);
          m_ownship_reference_altitude =
-               Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back());
+               Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl);
       } else if (ownship_reference_index == 0) {
          // beginning
          m_ownship_reference_cas =
@@ -460,14 +459,8 @@ void IMKinematicAchieve::CheckPredictionAccuracy(
                mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).altitude_msl;
       } else {
          // normal case, middle somewhere, so interpolate
-         m_ownship_reference_cas = Units::MetersPerSecondSpeed(CoreUtils::LinearlyInterpolate(
-               ownship_reference_index, Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-               m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-               m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities()));
-         m_ownship_reference_altitude = Units::MetersLength(CoreUtils::LinearlyInterpolate(
-               ownship_reference_index, Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-               m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-               m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes()));
+         m_ownship_reference_cas = Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).calibrated_airspeed);
+         m_ownship_reference_altitude = Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).altitude_msl);
       }
 
       std::shared_ptr<Atmosphere> sensed_atmosphere(GetAtmosphere()->Clone());
@@ -495,22 +488,18 @@ void IMKinematicAchieve::CheckPredictionAccuracy(
       CalculateTargetDtgToImPoints(targettruthstate);
 
       int target_reference_index =
-            CoreUtils::FindNearestIndex(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-                                        m_target_kinematic_trajectory_predictor.GetVerticalPathDistances());
-      if (target_reference_index + 1 >= m_target_kinematic_trajectory_predictor.GetVerticalPathTimes().size()) {
+            mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).resolved_index;
+      if (target_reference_index + 1 >= mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath())) {
          // end
          m_target_reference_altitude =
-               Units::MetersLength(m_target_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back());
+               Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl);
       } else if (target_reference_index == 0) {
          // beginning
          m_target_reference_altitude =
                mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).altitude_msl;
       } else {
          // normal case, middle somewhere, so interpolate
-         m_target_reference_altitude = Units::MetersLength(CoreUtils::LinearlyInterpolate(
-               target_reference_index, Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-               m_target_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-               m_target_kinematic_trajectory_predictor.GetVerticalPathAltitudes()));
+         m_target_reference_altitude = Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).altitude_msl);
       }
 
       Units::FeetLength target_altitude_error = m_target_reference_altitude - Units::FeetLength(targettruthstate.m_z);
@@ -1043,16 +1032,15 @@ void IMKinematicAchieve::SetTrafficReferencePointConstraints(
       // Speed case 1 / Altitude case 2
       // We need ownship's predicted speed and altitude at ABP
       Units::MetersLength abp_dtg = m_ownship_kinematic_achieve_by_calcs.GetDistanceFromWaypoint();
-      int ownship_achieve_by_index = CoreUtils::FindNearestIndex(
-            abp_dtg.value(), m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
+      int ownship_achieve_by_index = mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(abp_dtg.value())).resolved_index;
       Units::Speed ownship_cas_at_abp;
       Units::FeetLength ownship_altitude_at_abp;
-      if (ownship_achieve_by_index + 1 >= m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes().size()) {
+      if (ownship_achieve_by_index + 1 >= mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath())) {
          // end
          ownship_cas_at_abp =
-               Units::MetersPerSecondSpeed(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back());
+               Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed);
          ownship_altitude_at_abp =
-               Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back());
+               Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl);
       } else if (ownship_achieve_by_index == 0) {
          // beginning
          ownship_cas_at_abp =
@@ -1062,13 +1050,9 @@ void IMKinematicAchieve::SetTrafficReferencePointConstraints(
       } else {
          // normal case, middle somewhere, so interpolate
          ownship_cas_at_abp = Units::MetersPerSecondSpeed(
-               CoreUtils::LinearlyInterpolate(ownship_achieve_by_index, abp_dtg.value(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities()));
+               mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(abp_dtg.value())).calibrated_airspeed);
          ownship_altitude_at_abp = Units::MetersLength(
-               CoreUtils::LinearlyInterpolate(ownship_achieve_by_index, abp_dtg.value(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes()));
+               mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(abp_dtg.value())).altitude_msl);
       }
 
       // calculate ownship CAS

--- a/IntervalManagement/IMKinematicAchieve.cpp
+++ b/IntervalManagement/IMKinematicAchieve.cpp
@@ -114,14 +114,15 @@ void IMKinematicAchieve::Initialize(const OwnshipPredictionParameters &ownship_p
          ownship_prediction_parameters.aerodynamics, quantizer);
 
    // --- Prepare Ownship objects -------------
-   m_ownship_aircraft_intent = ownship_aircraft_intent;
+   m_ownship_aircraft_intent = FIMAircraftIntent::Builder(ownship_aircraft_intent).Build();
 
    // Create the kinematic trajectory predictors using ownship assumptions
    m_ownship_kinematic_trajectory_predictor = aaesim::open_source::KinematicTrajectoryPredictor(
          ownship_prediction_parameters.maximum_allowable_bank_angle, ownship_prediction_parameters.transition_ias,
          ownship_prediction_parameters.transition_mach, ownship_prediction_parameters.transition_altitude,
          ownship_prediction_parameters.expected_cruise_altitude);
-   m_ownship_kinematic_trajectory_predictor.CalculateWaypoints(m_ownship_aircraft_intent, weather_prediction);
+   m_ownship_kinematic_trajectory_predictor.CalculateWaypoints(
+         std::make_shared<FIMAircraftIntent>(m_ownship_aircraft_intent), weather_prediction);
 
    // Initialize these objects with an estimated horizontal path. The horizontal paths will be updated to a more precise
    // calculation during initial trajectory prediction.
@@ -144,7 +145,8 @@ void IMKinematicAchieve::Initialize(const OwnshipPredictionParameters &ownship_p
          ownship_prediction_parameters.transition_mach, ownship_prediction_parameters.transition_altitude,
          ownship_prediction_parameters.expected_cruise_altitude);
 
-   m_target_kinematic_trajectory_predictor.CalculateWaypoints(m_target_aircraft_intent, weather_prediction);
+   m_target_kinematic_trajectory_predictor.CalculateWaypoints(
+         std::make_shared<FIMAircraftIntent>(m_target_aircraft_intent), weather_prediction);
    m_target_distance_calculator = AlongPathDistanceCalculator(
          m_target_kinematic_trajectory_predictor.EstimateHorizontalTrajectory(weather_prediction),
          TrajectoryIndexProgressionDirection::DECREMENTING);
@@ -182,6 +184,13 @@ aaesim::open_source::Guidance IMKinematicAchieve::Update(
       const vector<interval_management::open_source::AircraftState> &targethistory) {
    aaesim::open_source::Guidance guidance_out =
          IMAchieve::Update(prevguidance, dynamicsstate, owntruthstate, targetsyncstate, targethistory);
+
+   m_ownship_aircraft_intent = FIMAircraftIntent::Builder(m_ownship_aircraft_intent)
+                                      .SetId(owntruthstate.GetId()).Build();
+   if (targetsyncstate.GetId() != IMUtils::UNINITIALIZED_AIRCRAFT_ID) {
+      m_target_aircraft_intent = FIMAircraftIntent::Builder(m_target_aircraft_intent)
+                                         .SetId(targetsyncstate.GetId()).Build();
+   }
 
    m_target_aircraft_exists = targetsyncstate.GetId() != IMUtils::UNINITIALIZED_AIRCRAFT_ID;
    m_target_history_exists = !targethistory.empty();
@@ -240,7 +249,8 @@ void IMKinematicAchieve::HandleTrajectoryPrediction(
 
    if (m_compute_ownship_kinematic_trajectory) {
       LOG4CPLUS_TRACE(logger, "compute ownship kinematic trajectory: " << owntruthstate.GetId());
-      m_ownship_kinematic_trajectory_predictor.CalculateWaypoints(m_ownship_aircraft_intent, m_weather_prediction);
+      m_ownship_kinematic_trajectory_predictor.CalculateWaypoints(
+            std::make_shared<FIMAircraftIntent>(m_ownship_aircraft_intent), m_weather_prediction);
 
       std::vector<HorizontalPath> ownship_horizontal_path =
             m_ownship_kinematic_trajectory_predictor.GetHorizontalPath();
@@ -351,7 +361,8 @@ void IMKinematicAchieve::HandleTrajectoryPrediction(
                   m_weather_prediction.getAtmosphere()->GetMachIASTransition(target_descent_cas,
                                                                              estimated_cruise_mach));
          }
-         m_target_kinematic_trajectory_predictor.CalculateWaypoints(m_target_aircraft_intent, m_weather_prediction);
+         m_target_kinematic_trajectory_predictor.CalculateWaypoints(
+               std::make_shared<FIMAircraftIntent>(m_target_aircraft_intent), m_weather_prediction);
 
          Units::RadiansAngle dummy_course = Units::RadiansAngle(0);
          std::vector<HorizontalPath>::size_type dummy_index = 0;
@@ -381,19 +392,22 @@ void IMKinematicAchieve::HandleTrajectoryPrediction(
             interval_management::open_source::AchievePointCalcs::ComputeDefaultTRP(
                   m_ownship_kinematic_achieve_by_calcs, m_ownship_aircraft_intent, m_target_aircraft_intent,
                   m_tangent_plane_sequence, target_horizontal_path, m_traffic_reference_point, x, y, index);
-            m_target_aircraft_intent.InsertWaypointAtIndex(m_traffic_reference_point, index);
+            m_target_aircraft_intent = FIMAircraftIntent::Builder(m_target_aircraft_intent)
+                                               .SetId(m_target_aircraft_intent.GetId())
+                                               .InsertWaypointAtIndex(m_traffic_reference_point, index).Build();
          } else {
             // retrieve TRP from target intent
             const size_t trp_index(m_target_aircraft_intent.GetWaypointIndexByName(trp_name));
             m_traffic_reference_point = m_target_aircraft_intent.GetWaypoint(trp_index);
          }
 
-         m_target_aircraft_intent = AircraftIntent::CopyAndTrimAfterNamedWaypoint(m_target_aircraft_intent,
+         m_target_aircraft_intent = FIMAircraftIntent::CopyAndTrimAfterNamedWaypoint(m_target_aircraft_intent,
                                                                                   m_traffic_reference_point.GetName());
 
          SetTrafficReferencePointConstraints(owntruthstate, targetsyncstate);
 
-         m_target_kinematic_trajectory_predictor.CalculateWaypoints(m_target_aircraft_intent, m_weather_prediction);
+         m_target_kinematic_trajectory_predictor.CalculateWaypoints(
+               std::make_shared<FIMAircraftIntent>(m_target_aircraft_intent), m_weather_prediction);
          m_target_kinematic_trajectory_predictor.BuildTrajectoryPrediction(
                m_weather_prediction, m_tangent_plane_sequence, target_start_altitude_msl, target_distance_to_go);
          m_target_kinematic_traffic_reference_point_calcs = interval_management::open_source::AchievePointCalcs(
@@ -847,15 +861,18 @@ void IMKinematicAchieve::ComputeFASTrajectories(
    // construct intents
    // final AC:  current_pos last_wp
    // vector AC:  current_pos merge_point last_wp
-   AircraftIntent own_intent(m_ownship_aircraft_intent), target_intent(m_target_aircraft_intent);
-   own_intent.ClearWaypoints();
-   target_intent.ClearWaypoints();
-   own_intent.SetPlannedCruiseAltitude(Units::FeetLength(owntruthstate.m_z));
-   target_intent.SetPlannedCruiseAltitude(Units::FeetLength(targettruthstate.m_z));
+   auto own_intent_builder = FIMAircraftIntent::Builder(m_ownship_aircraft_intent)
+                                   .SetId(m_ownship_aircraft_intent.GetId())
+                                   .ClearWaypoints()
+                                   .SetPlannedCruiseAltitude(Units::FeetLength(owntruthstate.m_z));
+   auto target_intent_builder = FIMAircraftIntent::Builder(m_target_aircraft_intent)
+                                      .SetId(m_target_aircraft_intent.GetId())
+                                      .ClearWaypoints()
+                                      .SetPlannedCruiseAltitude(Units::FeetLength(targettruthstate.m_z));
 
    Waypoint ptp_waypoint{m_ownship_aircraft_intent.GetWaypoint(achieve_by_waypoint_index)};
-   own_intent.InsertWaypointAtIndex(ptp_waypoint, 0);
-   target_intent.InsertWaypointAtIndex(target_end_waypoint, 0);
+   own_intent_builder.InsertWaypointAtIndex(ptp_waypoint, 0);
+   target_intent_builder.InsertWaypointAtIndex(target_end_waypoint, 0);
 
    pair<Units::Length, Units::Length> final_wpt_coords(x2, y2);
    pair<Units::Length, Units::Length> merge_coords(xMerge, yMerge);
@@ -878,9 +895,9 @@ void IMKinematicAchieve::ComputeFASTrajectories(
    LOG4CPLUS_TRACE(logger, "Merge to lastwpt = " << merge_to_lastwpt_distance);
 
    // convert states to waypoints, using ownship's sensed winds
-   own_intent.InsertWaypointAtIndex(MakeWaypointFromState(owntruthstate, owntruthstate.GetSensedWindEastComponent(),
-                                                          owntruthstate.GetSensedWindNorthComponent()),
-                                    0);
+   own_intent_builder.InsertWaypointAtIndex(
+         MakeWaypointFromState(owntruthstate, owntruthstate.GetSensedWindEastComponent(),
+                               owntruthstate.GetSensedWindNorthComponent()), 0);
 
    // Get predicted winds at target aircraft's current altitude & create waypoint
    Units::MetersPerSecondSpeed target_wind_x, target_wind_y;
@@ -889,7 +906,7 @@ void IMKinematicAchieve::ComputeFASTrajectories(
                                                                     target_wind_x, dVwx_dh);
    m_weather_prediction.north_south().CalculateWindGradientAtAltitude(Units::FeetLength(targettruthstate.m_z),
                                                                       target_wind_y, dVwy_dh);
-   target_intent.InsertWaypointAtIndex(MakeWaypointFromState(targettruthstate, target_wind_x, target_wind_y), 0);
+   target_intent_builder.InsertWaypointAtIndex(MakeWaypointFromState(targettruthstate, target_wind_x, target_wind_y), 0);
 
    const Units::DegreesAngle tolerance(10.0);
    const Units::NauticalMilesLength too_close(.85);  // see AAES-939, AAES-1061
@@ -906,16 +923,14 @@ void IMKinematicAchieve::ComputeFASTrajectories(
       LOG4CPLUS_WARN(logger, "Merge point discarded because it is near PTP.");
    } else {
       if (m_im_clearance.IsVectorAircraft()) {
-         own_intent.InsertPairAtIndex("merge", xMerge, yMerge, 1);
+         own_intent_builder.InsertPairAtIndex("merge", xMerge, yMerge, 1);
       } else {
-         target_intent.InsertPairAtIndex("merge", xMerge, yMerge, 1);
+         target_intent_builder.InsertPairAtIndex("merge", xMerge, yMerge, 1);
       }
    }
-   LOG4CPLUS_TRACE(logger, "Ownship AircraftIntent:" << endl << own_intent);
-   LOG4CPLUS_TRACE(logger, "Target AircraftIntent:" << endl << target_intent);
 
-   m_ownship_aircraft_intent = own_intent;
-   m_target_aircraft_intent = target_intent;
+   m_ownship_aircraft_intent = own_intent_builder.Build();
+   m_target_aircraft_intent = target_intent_builder.Build();
 
    m_compute_ownship_kinematic_trajectory = true;
    m_compute_target_kinematic_trajectory = true;
@@ -1087,5 +1102,7 @@ void IMKinematicAchieve::SetTrafficReferencePointConstraints(
    }
 
    LOG4CPLUS_TRACE(logger, "New TRP constraints:  " << m_traffic_reference_point);
-   m_target_aircraft_intent.UpdateWaypoint(m_traffic_reference_point);
+   m_target_aircraft_intent = FIMAircraftIntent::Builder(m_target_aircraft_intent)
+                                      .SetId(m_target_aircraft_intent.GetId())
+                                      .UpdateWaypoint(m_traffic_reference_point).Build();
 }

--- a/IntervalManagement/IMKinematicDistBasedMaintain.cpp
+++ b/IntervalManagement/IMKinematicDistBasedMaintain.cpp
@@ -42,26 +42,26 @@ void IMKinematicDistBasedMaintain::IterationReset() {
    m_measured_spacing_interval = Units::NegInfinity();
 }
 
-aaesim::open_source::Guidance IMKinematicDistBasedMaintain::Update(
-      const aaesim::open_source::DynamicsState &dynamics_state,
+mitre::oss::simcore::Guidance IMKinematicDistBasedMaintain::Update(
+      const mitre::oss::simcore::DynamicsState &dynamics_state,
       const interval_management::open_source::AircraftState &ownship_aircraft_state,
       const interval_management::open_source::AircraftState
             &target_state_projected_on_ownships_path_at_adjusted_distance,
       const Units::Length target_dtg_along_ownships_path_at_adjusted_distance,
       const Units::Length target_dtg_along_ownships_path,
-      const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-      const aaesim::open_source::Guidance &guidance_in,
+      const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+      const mitre::oss::simcore::Guidance &guidance_in,
       const std::vector<interval_management::open_source::AircraftState> &target_aircraft_state_history,
       const interval_management::open_source::AchievePointCalcs &ownship_achieve_point_calcs,
       const interval_management::open_source::AchievePointCalcs &traffic_reference_point_calcs,
-      aaesim::open_source::StatisticalPilotDelay &pilot_delay) {
+      mitre::oss::simcore::StatisticalPilotDelay &pilot_delay) {
    /*
     * Developer's note: In this level of the algorithm, all uses of the /target state/
     * must be projected onto ownship's route prior to use. This includes all items
     * in the targethistory vector (they have not already been projected). Some lower
     * level algorithms carry this load automatically
     */
-   aaesim::open_source::Guidance guidanceout = guidance_in;
+   mitre::oss::simcore::Guidance guidanceout = guidance_in;
 
    // target's along-path position on ownship's route (adjusted for ASG)
    Units::Length target_projected_dtg(target_dtg_along_ownships_path_at_adjusted_distance);
@@ -161,9 +161,9 @@ aaesim::open_source::Guidance IMKinematicDistBasedMaintain::Update(
 
 void IMKinematicDistBasedMaintain::CalculateIas(
       const Units::Length current_ownship_altitude, const Units::Length target_kinematic_dtg_to_end_of_route,
-      const aaesim::open_source::DynamicsState &dynamics_state,
-      const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-      aaesim::open_source::StatisticalPilotDelay &pilot_delay) {
+      const mitre::oss::simcore::DynamicsState &dynamics_state,
+      const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+      mitre::oss::simcore::StatisticalPilotDelay &pilot_delay) {
    m_im_speed_command_ias = m_speed_limiter.LimitSpeedCommand(
          m_previous_im_speed_command_ias, m_im_speed_command_ias,
          ownship_kinematic_trajectory_predictor.GetVerticalPathCasByIndex(m_ownship_reference_lookup_index),
@@ -186,8 +186,8 @@ void IMKinematicDistBasedMaintain::CalculateIas(
 void IMKinematicDistBasedMaintain::CalculateMach(
       const Units::Length current_ownship_altitude, const Units::Length target_kinematic_dtg_to_end_of_route,
       const Units::Speed true_airspeed_command,
-      const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-      aaesim::open_source::StatisticalPilotDelay &pilot_delay, const Units::Mass current_mass) {
+      const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+      mitre::oss::simcore::StatisticalPilotDelay &pilot_delay, const Units::Mass current_mass) {
    Units::Speed nominal_profile_ias = Units::MetersPerSecondSpeed(
          ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(m_ownship_reference_lookup_index));
    Units::Speed nominal_profile_tas =
@@ -232,10 +232,10 @@ void IMKinematicDistBasedMaintain::CalculateMach(
 void IMKinematicDistBasedMaintain::RecordInternalObserverData(
       const interval_management::open_source::AircraftState &ownship_aircraft_state,
       const interval_management::open_source::AircraftState &target_aircraft_state,
-      const aaesim::open_source::DynamicsState &dynamics_state, const Units::Speed true_airspeed_command,
+      const mitre::oss::simcore::DynamicsState &dynamics_state, const Units::Speed true_airspeed_command,
       const Units::Length target_true_dtg, const Units::Length ownship_true_dtg,
       const std::vector<interval_management::open_source::AircraftState> &target_aircraft_state_history,
-      const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor) {
+      const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor) {
    InternalObserver::getInstance()->updateFinalGS(
          target_aircraft_state.GetId(),
          Units::MetersPerSecondSpeed(target_aircraft_state_history.back().GetGroundSpeed()).value());

--- a/IntervalManagement/IMKinematicDistBasedMaintain.cpp
+++ b/IntervalManagement/IMKinematicDistBasedMaintain.cpp
@@ -72,23 +72,23 @@ mitre::oss::simcore::Guidance IMKinematicDistBasedMaintain::Update(
          ownship_aircraft_state.GetPositionX(), ownship_aircraft_state.GetPositionY(), ownship_estimated_dtg);
 
    if (ownship_estimated_dtg <=
-       Units::MetersLength(ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().back())) {
+       Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).along_path_distance)) {
       guidanceout.SetValid(true);
 
       m_measured_spacing_interval = ownship_estimated_dtg - target_dtg_along_ownships_path;
 
       if (m_previous_reference_im_speed_command_tas == Units::zero()) {
          m_previous_reference_im_speed_command_tas = m_weather_prediction.getAtmosphere()->CAS2TAS(
-               Units::MetersPerSecondSpeed(ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back()),
-               Units::MetersLength(ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back()));
+               Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed),
+               Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl));
          m_previous_im_speed_command_ias =
-               Units::MetersPerSecondSpeed(ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back());
+               Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed);
          m_previous_reference_im_speed_command_mach =
                Units::MetersPerSecondSpeed(m_previous_reference_im_speed_command_tas).value() /
                sqrt(kGamma * R.value() *
                     m_weather_prediction.getAtmosphere()
                           ->GetTemperature(Units::MetersLength(
-                                ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back()))
+                                mitre::oss::simcore::VerticalPathUtils::GetLastPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl))
                           .value());
       }
 
@@ -112,8 +112,7 @@ mitre::oss::simcore::Guidance IMKinematicDistBasedMaintain::Update(
       m_unmodified_im_speed_command_ias = m_im_speed_command_ias;
 
       m_ownship_reference_lookup_index =
-            CoreUtils::FindNearestIndex(Units::MetersLength(ownship_estimated_dtg).value(),
-                                        ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
+            mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(ownship_estimated_dtg).value())).resolved_index;
 
       if (guidanceout.GetSelectedSpeed().GetSpeedType() == INDICATED_AIR_SPEED) {
          CalculateIas(Units::FeetLength(ownship_aircraft_state.m_z), target_dtg_along_ownships_path, dynamics_state,
@@ -151,7 +150,7 @@ mitre::oss::simcore::Guidance IMKinematicDistBasedMaintain::Update(
                                  target_aircraft_state_history, ownship_kinematic_trajectory_predictor);
    } else {
       m_ownship_reference_lookup_index =
-            static_cast<int>(ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1);
+            static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
 
       guidanceout.SetValid(false);
       m_measured_spacing_interval = Units::NegInfinity();
@@ -212,8 +211,7 @@ void IMKinematicDistBasedMaintain::CalculateMach(
    } else {
       m_measured_spacing_interval = Units::NegInfinity();
       m_ownship_reference_lookup_index =
-            CoreUtils::FindNearestIndex(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-                                        ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
+            mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).resolved_index;
       temp_mach = std::min(nominal_mach, BoundedValue<double, 0, 2>(m_previous_reference_im_speed_command_mach));
    }
 

--- a/IntervalManagement/IMKinematicDistBasedMaintain.cpp
+++ b/IntervalManagement/IMKinematicDistBasedMaintain.cpp
@@ -26,6 +26,7 @@
 #include "imalgs/InternalObserver.h"
 #include "public/CoreUtils.h"
 #include "public/CustomMath.h"
+#include "public/VerticalPathUtils.h"
 
 using namespace interval_management::open_source;
 
@@ -189,7 +190,7 @@ void IMKinematicDistBasedMaintain::CalculateMach(
       const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
       mitre::oss::simcore::StatisticalPilotDelay &pilot_delay, const Units::Mass current_mass) {
    Units::Speed nominal_profile_ias = Units::MetersPerSecondSpeed(
-         ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(m_ownship_reference_lookup_index));
+         mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed);
    Units::Speed nominal_profile_tas =
          m_weather_prediction.getAtmosphere()->CAS2TAS(nominal_profile_ias, current_ownship_altitude);
 
@@ -263,10 +264,14 @@ void IMKinematicDistBasedMaintain::RecordInternalObserverData(
       if (ownship_true_dtg <= Units::NauticalMilesLength(nm_observer.curr_NM)) {
          --nm_observer.curr_NM;
 
-         double lval = m_speed_limiter.LowLimit(
-               ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(m_ownship_reference_lookup_index));
-         double hval = m_speed_limiter.HighLimit(
-               ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(m_ownship_reference_lookup_index));
+         double lval = Units::MetersPerSecondSpeed(m_speed_limiter.LowLimit(
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(
+                     ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(),
+                     m_ownship_reference_lookup_index).calibrated_airspeed)).value();
+         double hval = Units::MetersPerSecondSpeed(m_speed_limiter.HighLimit(
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(
+                     ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(),
+                     m_ownship_reference_lookup_index).calibrated_airspeed)).value();
 
          double ltas = Units::MetersPerSecondSpeed(
                              m_weather_prediction.getAtmosphere()->CAS2TAS(

--- a/IntervalManagement/IMKinematicDistBasedMaintain.cpp
+++ b/IntervalManagement/IMKinematicDistBasedMaintain.cpp
@@ -167,10 +167,11 @@ void IMKinematicDistBasedMaintain::CalculateIas(
       mitre::oss::simcore::StatisticalPilotDelay &pilot_delay) {
    m_im_speed_command_ias = m_speed_limiter.LimitSpeedCommand(
          m_previous_im_speed_command_ias, m_im_speed_command_ias,
-         ownship_kinematic_trajectory_predictor.GetVerticalPathCasByIndex(m_ownship_reference_lookup_index),
+         mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed,
          Units::ZERO_LENGTH,
-         Units::MetersLength(
-               ownship_kinematic_trajectory_predictor.GetVerticalPathDistanceByIndex(m_ownship_reference_lookup_index)),
+         mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(
+               ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(),
+               m_ownship_reference_lookup_index).along_path_distance,
          current_ownship_altitude, dynamics_state.flap_configuration);
 
    if (m_im_speed_command_ias != m_previous_im_speed_command_ias) {

--- a/IntervalManagement/IMKinematicDistBasedMaintain.cpp
+++ b/IntervalManagement/IMKinematicDistBasedMaintain.cpp
@@ -114,7 +114,7 @@ mitre::oss::simcore::Guidance IMKinematicDistBasedMaintain::Update(
       m_ownship_reference_lookup_index =
             mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(ownship_estimated_dtg).value())).resolved_index;
 
-      if (guidanceout.GetSelectedSpeed().GetSpeedType() == INDICATED_AIR_SPEED) {
+      if (guidanceout.GetSelectedSpeedType() == INDICATED_AIR_SPEED) {
          CalculateIas(Units::FeetLength(ownship_aircraft_state.m_z), target_dtg_along_ownships_path, dynamics_state,
                       ownship_kinematic_trajectory_predictor, pilot_delay);
       } else {
@@ -127,7 +127,7 @@ mitre::oss::simcore::Guidance IMKinematicDistBasedMaintain::Update(
 
       if (pilot_delay.IsPilotDelayOn()) {
          guidanceout.m_ias_command = m_im_speed_command_with_pilot_delay;
-         if (guidanceout.GetSelectedSpeed().GetSpeedType() == MACH_SPEED) {
+         if (guidanceout.GetSelectedSpeedType() == MACH_SPEED) {
             const auto true_airspeed_equivalent = m_weather_prediction.CAS2TAS(m_im_speed_command_with_pilot_delay,
                                                                                ownship_aircraft_state.GetPositionZ());
             const auto mach_equivalent =
@@ -136,7 +136,7 @@ mitre::oss::simcore::Guidance IMKinematicDistBasedMaintain::Update(
          }
       } else {
          guidanceout.m_ias_command = m_im_speed_command_ias;
-         if (guidanceout.GetSelectedSpeed().GetSpeedType() == MACH_SPEED) {
+         if (guidanceout.GetSelectedSpeedType() == MACH_SPEED) {
             const auto true_airspeed_equivalent =
                   m_weather_prediction.CAS2TAS(m_im_speed_command_ias, ownship_aircraft_state.GetPositionZ());
             const auto mach_equivalent =

--- a/IntervalManagement/IMKinematicTimeBasedMaintain.cpp
+++ b/IntervalManagement/IMKinematicTimeBasedMaintain.cpp
@@ -37,16 +37,16 @@ IMKinematicTimeBasedMaintain::IMKinematicTimeBasedMaintain() { m_stage_of_im_ope
 
 IMKinematicTimeBasedMaintain::~IMKinematicTimeBasedMaintain() = default;
 
-aaesim::open_source::Guidance IMKinematicTimeBasedMaintain::Update(
-      const aaesim::open_source::DynamicsState &dynamics_state,
+mitre::oss::simcore::Guidance IMKinematicTimeBasedMaintain::Update(
+      const mitre::oss::simcore::DynamicsState &dynamics_state,
       const interval_management::open_source::AircraftState &ownship_aircraft_state,
       const interval_management::open_source::AircraftState &target_aircraft_state_projected_asg_adjusted,
-      const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-      const aaesim::open_source::Guidance &guidance_in,
+      const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+      const mitre::oss::simcore::Guidance &guidance_in,
       const std::vector<interval_management::open_source::AircraftState> &target_aircraft_state_history,
       const interval_management::open_source::AchievePointCalcs &ownship_achieve_point_calcs,
       const interval_management::open_source::AchievePointCalcs &traffic_reference_point_calcs,
-      aaesim::open_source::StatisticalPilotDelay &pilot_delay_model,
+      mitre::oss::simcore::StatisticalPilotDelay &pilot_delay_model,
       const Units::Length &target_kinematic_dtg_to_end_of_route) {
    /*
     * Developer's note: In this level of the algorithm, all uses of the /target state/
@@ -54,7 +54,7 @@ aaesim::open_source::Guidance IMKinematicTimeBasedMaintain::Update(
     * in the target_aircraft_state_history vector (they have not been projected). Some lower
     * level algorithms carry this load automatically
     */
-   aaesim::open_source::Guidance guidance_out = guidance_in;
+   mitre::oss::simcore::Guidance guidance_out = guidance_in;
    guidance_out.SetValid(true);
 
    Units::MetersLength tmpdist;
@@ -255,9 +255,9 @@ aaesim::open_source::Guidance IMKinematicTimeBasedMaintain::Update(
 }
 
 void IMKinematicTimeBasedMaintain::CalculateIas(
-      const Units::Length current_ownship_altitude, const aaesim::open_source::DynamicsState &dynamics_state,
-      const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-      aaesim::open_source::StatisticalPilotDelay &pilot_delay) {
+      const Units::Length current_ownship_altitude, const mitre::oss::simcore::DynamicsState &dynamics_state,
+      const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+      mitre::oss::simcore::StatisticalPilotDelay &pilot_delay) {
    m_im_speed_command_ias = m_speed_limiter.LimitSpeedCommand(
          m_previous_im_speed_command_ias, m_im_speed_command_ias,
          ownship_kinematic_trajectory_predictor.GetVerticalPathCasByIndex(m_ownship_reference_lookup_index),
@@ -279,8 +279,8 @@ void IMKinematicTimeBasedMaintain::CalculateIas(
 
 void IMKinematicTimeBasedMaintain::CalculateMach(
       const Units::Length current_ownship_altitude, const Units::Speed true_airspeed_command,
-      const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-      aaesim::open_source::StatisticalPilotDelay &pilot_delay, const Units::Mass current_mass) {
+      const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+      mitre::oss::simcore::StatisticalPilotDelay &pilot_delay, const Units::Mass current_mass) {
    // Make sure velocity is within nominal limits (AAES-694)
    Units::Speed nominal_profile_ias = Units::MetersPerSecondSpeed(
          ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(m_ownship_reference_lookup_index));

--- a/IntervalManagement/IMKinematicTimeBasedMaintain.cpp
+++ b/IntervalManagement/IMKinematicTimeBasedMaintain.cpp
@@ -100,7 +100,7 @@ mitre::oss::simcore::Guidance IMKinematicTimeBasedMaintain::Update(
 
    if (m_ownship_reference_lookup_index == -1) {
       m_ownship_reference_lookup_index =
-            static_cast<int>(ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1);
+            static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
    }
 
    // if target distance is inside the range of the precalculated trajectory, use that to find the precalc index for the
@@ -108,15 +108,14 @@ mitre::oss::simcore::Guidance IMKinematicTimeBasedMaintain::Update(
    if (target_aircraft_state_projected_asg_adjusted.GetId() != IMUtils::UNINITIALIZED_AIRCRAFT_ID &&
        foundProjectedPos) {
       if (Units::abs(ownship_estimated_dtg) <=
-          Units::abs(Units::MetersLength(ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().back()))) {
+          Units::abs(Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).along_path_distance))) {
          m_ownship_reference_lookup_index =
-               CoreUtils::FindNearestIndex(Units::MetersLength(ownship_estimated_dtg).value(),
-                                           ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
+               mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(ownship_estimated_dtg).value())).resolved_index;
 
          if (m_ownship_reference_lookup_index >
-             ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1) {
+             mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1) {
             m_ownship_reference_lookup_index =
-                  static_cast<int>(ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1);
+                  static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
          }
       } else {
          guidance_out.SetValid(false);
@@ -137,16 +136,16 @@ mitre::oss::simcore::Guidance IMKinematicTimeBasedMaintain::Update(
          if (m_previous_reference_im_speed_command_tas == Units::zero()) {
             m_previous_reference_im_speed_command_tas = m_weather_prediction.getAtmosphere()->CAS2TAS(
                   Units::MetersPerSecondSpeed(
-                        ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back()),
-                  Units::MetersLength(ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back()));
+                        mitre::oss::simcore::VerticalPathUtils::GetLastPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed),
+                  Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl));
             m_previous_im_speed_command_ias = Units::MetersPerSecondSpeed(
-                  ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back());
+                  mitre::oss::simcore::VerticalPathUtils::GetLastPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed);
             m_previous_reference_im_speed_command_mach =
                   Units::MetersPerSecondSpeed(m_previous_reference_im_speed_command_tas).value() /
                   sqrt(kGamma * R.value() *
                        m_weather_prediction.getAtmosphere()
                              ->GetTemperature(Units::MetersLength(
-                                   ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back()))
+                                   mitre::oss::simcore::VerticalPathUtils::GetLastPathData(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl))
                              .value());
          }
 

--- a/IntervalManagement/IMKinematicTimeBasedMaintain.cpp
+++ b/IntervalManagement/IMKinematicTimeBasedMaintain.cpp
@@ -183,7 +183,7 @@ mitre::oss::simcore::Guidance IMKinematicTimeBasedMaintain::Update(
             m_weather_prediction.getAtmosphere()->TAS2CAS(tascommand, Units::FeetLength(ownship_aircraft_state.m_z));
       m_unmodified_im_speed_command_ias = m_im_speed_command_ias;
 
-      if (guidance_out.GetSelectedSpeed().GetSpeedType() == INDICATED_AIR_SPEED) {
+      if (guidance_out.GetSelectedSpeedType() == INDICATED_AIR_SPEED) {
          CalculateIas(Units::FeetLength(ownship_aircraft_state.m_z), dynamics_state,
                       ownship_kinematic_trajectory_predictor, pilot_delay_model);
       } else {
@@ -199,7 +199,7 @@ mitre::oss::simcore::Guidance IMKinematicTimeBasedMaintain::Update(
 
       if (pilot_delay_model.IsPilotDelayOn()) {
          guidance_out.m_ias_command = m_im_speed_command_with_pilot_delay;
-         if (guidance_out.GetSelectedSpeed().GetSpeedType() == MACH_SPEED) {
+         if (guidance_out.GetSelectedSpeedType() == MACH_SPEED) {
             const auto true_airspeed_equivalent =
                   m_weather_prediction.CAS2TAS(m_im_speed_command_ias, ownship_aircraft_state.GetPositionZ());
             const auto mach_equivalent =
@@ -208,7 +208,7 @@ mitre::oss::simcore::Guidance IMKinematicTimeBasedMaintain::Update(
          }
       } else {
          guidance_out.m_ias_command = m_im_speed_command_ias;
-         if (guidance_out.GetSelectedSpeed().GetSpeedType() == MACH_SPEED) {
+         if (guidance_out.GetSelectedSpeedType() == MACH_SPEED) {
             guidance_out.SetMachCommand(m_previous_reference_im_speed_command_mach);
          }
       }

--- a/IntervalManagement/IMKinematicTimeBasedMaintain.cpp
+++ b/IntervalManagement/IMKinematicTimeBasedMaintain.cpp
@@ -263,10 +263,11 @@ void IMKinematicTimeBasedMaintain::CalculateIas(
       mitre::oss::simcore::StatisticalPilotDelay &pilot_delay) {
    m_im_speed_command_ias = m_speed_limiter.LimitSpeedCommand(
          m_previous_im_speed_command_ias, m_im_speed_command_ias,
-         ownship_kinematic_trajectory_predictor.GetVerticalPathCasByIndex(m_ownship_reference_lookup_index),
+         mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed,
          Units::ZERO_LENGTH,
-         Units::MetersLength(
-               ownship_kinematic_trajectory_predictor.GetVerticalPathDistanceByIndex(m_ownship_reference_lookup_index)),
+         mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(
+               ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(),
+               m_ownship_reference_lookup_index).along_path_distance,
          current_ownship_altitude, dynamics_state.flap_configuration);
 
    if (m_im_speed_command_ias != m_previous_im_speed_command_ias) {

--- a/IntervalManagement/IMKinematicTimeBasedMaintain.cpp
+++ b/IntervalManagement/IMKinematicTimeBasedMaintain.cpp
@@ -27,6 +27,7 @@
 #include "public/CoreUtils.h"
 #include "public/CustomMath.h"
 #include "public/SimulationTime.h"
+#include "public/VerticalPathUtils.h"
 
 using namespace interval_management::open_source;
 
@@ -225,12 +226,14 @@ mitre::oss::simcore::Guidance IMKinematicTimeBasedMaintain::Update(
              guidance_out.IsValid()) {
             --nm_observer.curr_NM;
 
-            double lval =
-                  m_speed_limiter.LowLimit(ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(
-                        m_ownship_reference_lookup_index));
-            double hval =
-                  m_speed_limiter.HighLimit(ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(
-                        m_ownship_reference_lookup_index));
+            double lval = Units::MetersPerSecondSpeed(m_speed_limiter.LowLimit(
+                  mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(
+                        ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(),
+                        m_ownship_reference_lookup_index).calibrated_airspeed)).value();
+            double hval = Units::MetersPerSecondSpeed(m_speed_limiter.HighLimit(
+                  mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(
+                        ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(),
+                        m_ownship_reference_lookup_index).calibrated_airspeed)).value();
 
             double ltas = Units::MetersPerSecondSpeed(
                                 m_weather_prediction.getAtmosphere()->CAS2TAS(
@@ -283,7 +286,7 @@ void IMKinematicTimeBasedMaintain::CalculateMach(
       mitre::oss::simcore::StatisticalPilotDelay &pilot_delay, const Units::Mass current_mass) {
    // Make sure velocity is within nominal limits (AAES-694)
    Units::Speed nominal_profile_ias = Units::MetersPerSecondSpeed(
-         ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(m_ownship_reference_lookup_index));
+         mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed);
    Units::Speed nominal_profile_tas =
          m_weather_prediction.getAtmosphere()->CAS2TAS(nominal_profile_ias, current_ownship_altitude);
 

--- a/IntervalManagement/IMMaintain.cpp
+++ b/IntervalManagement/IMMaintain.cpp
@@ -57,8 +57,8 @@ void IMMaintain::InitializeScenario(IMAchieve *obj, const Units::Frequency maint
 
 void IMMaintain::Prepare(Units::Speed previous_im_speed_command, Units::Speed previous_ias_command,
                          interval_management::open_source::FIMSpeedLimiter speed_limiter, double previous_mach_command,
-                         const aaesim::open_source::EuclideanTrajectoryPredictor &ownship_trajectory_predictor,
-                         const aaesim::open_source::AlongPathDistanceCalculator &im_distance_calculator,
+                         const mitre::oss::simcore::EuclideanTrajectoryPredictor &ownship_trajectory_predictor,
+                         const mitre::oss::simcore::AlongPathDistanceCalculator &im_distance_calculator,
                          const std::vector<interval_management::open_source::AircraftState> &target_adsb_track_history,
                          const IMClearance &im_clearance,
                          const std::vector<interval_management::open_source::FIMSpeedLimiter::RfLegLimit> &rf_limits) {
@@ -66,9 +66,9 @@ void IMMaintain::Prepare(Units::Speed previous_im_speed_command, Units::Speed pr
    m_previous_reference_im_speed_command_tas = previous_im_speed_command;
    m_previous_im_speed_command_ias = previous_ias_command;
    m_previous_reference_im_speed_command_mach = previous_mach_command;
-   m_ownship_decrementing_distance_calculator = aaesim::open_source::AlongPathDistanceCalculator(
+   m_ownship_decrementing_distance_calculator = mitre::oss::simcore::AlongPathDistanceCalculator(
          ownship_trajectory_predictor.GetHorizontalPath(),
-         aaesim::open_source::TrajectoryIndexProgressionDirection::DECREMENTING);
+         mitre::oss::simcore::TrajectoryIndexProgressionDirection::DECREMENTING);
    m_ownship_distance_calculator = im_distance_calculator;
    m_speed_limiter = speed_limiter;
 

--- a/IntervalManagement/IMTimeBasedAchieve.cpp
+++ b/IntervalManagement/IMTimeBasedAchieve.cpp
@@ -143,14 +143,13 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::Update(
                   TestForTrafficAlignment(current_ownship_state, target_adsb_history);
                }
 
-               AircraftSpeed aircraft_speed = guidance_out.GetSelectedSpeed();
-               if (aircraft_speed.GetSpeedType() != INDICATED_AIR_SPEED) {
+               if (guidance_out.GetSelectedSpeedType() != INDICATED_AIR_SPEED) {
                   LOG4CPLUS_FATAL(m_logger,
                                   "AircraftSpeed SpeedValueType not INDICATED_AIR_SPEED.  "
                                   "Unable to update guidance for CAPTURE clearance");
                }
 
-               m_im_speed_command_ias = Units::KnotsSpeed(aircraft_speed.GetValue());
+               m_im_speed_command_ias = guidance_out.m_ias_command;
                m_previous_im_speed_command_ias = m_im_speed_command_ias;
                guidance_out.m_ias_command = m_im_speed_command_ias;
             } else {
@@ -340,7 +339,7 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
 
    m_unmodified_im_speed_command_ias = m_im_speed_command_ias;
 
-   if (guidance_out.GetSelectedSpeed().GetSpeedType() == INDICATED_AIR_SPEED) {
+   if (guidance_out.GetSelectedSpeedType() == INDICATED_AIR_SPEED) {
       CalculateIas(Units::FeetLength(current_ownship_state.m_z), three_dof_dynamics_state);
    } else {
       CalculateMach(reference_ttg, Units::FeetLength(current_ownship_state.m_z), three_dof_dynamics_state.current_mass);
@@ -356,7 +355,7 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
 
    if (m_pilot_delay.IsPilotDelayOn()) {
       guidance_out.m_ias_command = m_im_speed_command_with_pilot_delay;
-      if (guidance_out.GetSelectedSpeed().GetSpeedType() == MACH_SPEED) {
+      if (guidance_out.GetSelectedSpeedType() == MACH_SPEED) {
          const auto true_airspeed_equivalent =
                m_weather_prediction.CAS2TAS(m_im_speed_command_with_pilot_delay, current_ownship_state.GetPositionZ());
          const auto mach_equivalent =
@@ -365,7 +364,7 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
       }
    } else {
       guidance_out.m_ias_command = m_im_speed_command_ias;
-      if (guidance_out.GetSelectedSpeed().GetSpeedType() == MACH_SPEED) {
+      if (guidance_out.GetSelectedSpeedType() == MACH_SPEED) {
          const auto true_airspeed_equivalent =
                m_weather_prediction.CAS2TAS(m_im_speed_command_ias, current_ownship_state.GetPositionZ());
          const auto mach_equivalent =

--- a/IntervalManagement/IMTimeBasedAchieve.cpp
+++ b/IntervalManagement/IMTimeBasedAchieve.cpp
@@ -28,7 +28,7 @@
 #include "public/CustomMath.h"
 
 using namespace std;
-using namespace aaesim::open_source;
+using namespace mitre::oss::simcore;
 using namespace interval_management::open_source;
 
 log4cplus::Logger IMTimeBasedAchieve::m_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("IMTimeBasedAchieve"));
@@ -107,13 +107,13 @@ bool IMTimeBasedAchieve::load(DecodedStream *input) {
    return loaded;
 }
 
-aaesim::open_source::Guidance IMTimeBasedAchieve::Update(
-      const aaesim::open_source::Guidance &previous_im_guidance,
-      const aaesim::open_source::DynamicsState &three_dof_dynamics_state,
+mitre::oss::simcore::Guidance IMTimeBasedAchieve::Update(
+      const mitre::oss::simcore::Guidance &previous_im_guidance,
+      const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state,
       const interval_management::open_source::AircraftState &current_ownship_state,
       const interval_management::open_source::AircraftState &current_target_state,
       const vector<interval_management::open_source::AircraftState> &target_adsb_history) {
-   aaesim::open_source::Guidance guidance_out =
+   mitre::oss::simcore::Guidance guidance_out =
          IMKinematicAchieve::Update(previous_im_guidance, three_dof_dynamics_state, current_ownship_state,
                                     current_target_state, target_adsb_history);
 
@@ -166,11 +166,11 @@ aaesim::open_source::Guidance IMTimeBasedAchieve::Update(
    return guidance_out;
 }
 
-aaesim::open_source::Guidance IMTimeBasedAchieve::HandleAchieveStage(
+mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
       const interval_management::open_source::AircraftState &current_ownship_state,
       const interval_management::open_source::AircraftState &current_target_state,
       const vector<interval_management::open_source::AircraftState> &target_adsb_history,
-      const aaesim::open_source::DynamicsState &three_dof_dynamics_state, aaesim::open_source::Guidance &guidance_out) {
+      const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state, mitre::oss::simcore::Guidance &guidance_out) {
    m_stage_of_im_operation = ACHIEVE;
 
    Units::Time reference_ttg = Units::zero();
@@ -445,12 +445,12 @@ void IMTimeBasedAchieve::TestForTrafficAlignment(
    }
 }
 
-aaesim::open_source::Guidance IMTimeBasedAchieve::HandleMaintainStage(
+mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleMaintainStage(
       const interval_management::open_source::AircraftState &current_ownship_state,
       const interval_management::open_source::AircraftState &current_target_state,
       const vector<interval_management::open_source::AircraftState> &target_adsb_history,
-      const aaesim::open_source::DynamicsState &three_dof_dynamics_state,
-      const aaesim::open_source::Guidance &previous_im_guidance, aaesim::open_source::Guidance &guidance_out) {
+      const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state,
+      const mitre::oss::simcore::Guidance &previous_im_guidance, mitre::oss::simcore::Guidance &guidance_out) {
    m_ownship_ttg_to_abp = Units::zero();
    m_ownship_kinematic_dtg_to_abp = Units::zero();
    m_predicted_spacing_interval = Units::NegInfinity();
@@ -570,7 +570,7 @@ void IMTimeBasedAchieve::SaveTargetStateAtTrafficAlignment(
 }
 
 void IMTimeBasedAchieve::CalculateIas(const Units::Length current_ownship_altitude,
-                                      const aaesim::open_source::DynamicsState &three_dof_dynamics_state) {
+                                      const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state) {
    m_im_speed_command_ias = m_speed_limiter.LimitSpeedCommand(
          m_previous_im_speed_command_ias, m_im_speed_command_ias,
          m_ownship_kinematic_trajectory_predictor.GetVerticalPathCasByIndex(m_ownship_reference_lookup_index),
@@ -633,9 +633,9 @@ void IMTimeBasedAchieve::CalculateMach(const Units::Time reference_ttg, const Un
 void IMTimeBasedAchieve::RecordInternalObserverMetrics(
       const interval_management::open_source::AircraftState &current_ownship_state,
       const interval_management::open_source::AircraftState &current_target_state,
-      const aaesim::open_source::DynamicsState &dynamics_state, const Units::Speed unmodified_ias,
+      const mitre::oss::simcore::DynamicsState &dynamics_state, const Units::Speed unmodified_ias,
       const Units::Speed tas_command, const Units::Speed reference_velocity, const Units::Length reference_distance,
-      const aaesim::open_source::Guidance &guidance) {
+      const mitre::oss::simcore::Guidance &guidance) {
    if (InternalObserver::getInstance()->outputNM()) {
       NMObserver &nm_observer = InternalObserver::getInstance()->GetNMObserver(current_ownship_state.GetId());
 
@@ -699,7 +699,7 @@ const Units::Speed IMTimeBasedAchieve::GetImSpeedCommandIas() const {
 
 void IMTimeBasedAchieve::Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                                     const AircraftIntent &ownship_aircraft_intent,
-                                    aaesim::open_source::WeatherPrediction &weather_prediction,
+                                    mitre::oss::simcore::WeatherPrediction &weather_prediction,
                                     std::shared_ptr<TangentPlaneSequence> &position_converter) {
    SetTangentPlaneSequence(position_converter);
    IMKinematicAchieve::Initialize(ownship_prediction_parameters, ownship_aircraft_intent, weather_prediction);

--- a/IntervalManagement/IMTimeBasedAchieve.cpp
+++ b/IntervalManagement/IMTimeBasedAchieve.cpp
@@ -124,11 +124,11 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::Update(
 
       if (m_target_reference_lookup_index == -1) {
          m_target_reference_lookup_index =
-               static_cast<int>(m_target_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1);
+               static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
          m_ownship_reference_lookup_index =
-               static_cast<int>(m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1);
+               static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
          m_reference_precalc_index =
-               static_cast<int>(m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().size() - 1);
+               static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
       }
 
       if (InAchieveStage()) {
@@ -189,8 +189,7 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
 
    if (m_target_aircraft_exists && !IsTargetPassedTrp()) {
       m_target_reference_lookup_index =
-            CoreUtils::FindNearestIndex(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-                                        m_target_kinematic_trajectory_predictor.GetVerticalPathDistances());
+            mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).resolved_index;
 
       if (m_target_reference_lookup_index == 0) {
          m_target_ttg_to_end_of_route =
@@ -201,22 +200,10 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
                Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).calibrated_airspeed);
          m_target_reference_gs = Units::MetersPerSecondSpeed(0);
       } else {
-         m_target_ttg_to_end_of_route = Units::SecondsTime(CoreUtils::LinearlyInterpolate(
-               m_target_reference_lookup_index, Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-               m_target_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-               m_target_kinematic_trajectory_predictor.GetVerticalPathTimes()));
-         m_target_reference_altitude = Units::MetersLength(CoreUtils::LinearlyInterpolate(
-               m_target_reference_lookup_index, Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-               m_target_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-               m_target_kinematic_trajectory_predictor.GetVerticalPathAltitudes()));
-         m_target_reference_ias = Units::MetersPerSecondSpeed(CoreUtils::LinearlyInterpolate(
-               m_target_reference_lookup_index, Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-               m_target_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-               m_target_kinematic_trajectory_predictor.GetVerticalPathVelocities()));
-         m_target_reference_gs = Units::MetersPerSecondSpeed(CoreUtils::LinearlyInterpolate(
-               m_target_reference_lookup_index, Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value(),
-               m_target_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-               m_target_kinematic_trajectory_predictor.GetVerticalPathGroundspeeds()));
+         m_target_ttg_to_end_of_route = Units::SecondsTime(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).time_to_go);
+         m_target_reference_altitude = Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).altitude_msl);
+         m_target_reference_ias = Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).calibrated_airspeed);
+         m_target_reference_gs = Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_target_kinematic_dtg_to_last_waypoint).value())).ground_speed);
       }
 
       m_target_ttg_to_trp =
@@ -243,25 +230,24 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
 
    if (m_previous_im_speed_command_ias == Units::zero()) {
       m_previous_reference_im_speed_command_tas = m_weather_prediction.getAtmosphere()->CAS2TAS(
-            Units::MetersPerSecondSpeed(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back()),
-            Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back()));
+            Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed),
+            Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl));
       m_previous_im_speed_command_ias =
-            Units::MetersPerSecondSpeed(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back());
+            Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed);
 
       m_previous_reference_im_speed_command_mach =
             Units::MetersPerSecondSpeed(m_previous_reference_im_speed_command_tas).value() /
             sqrt(kGamma * R.value() *
                  m_weather_prediction.getAtmosphere()
                        ->GetTemperature(Units::MetersLength(
-                             m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back()))
+                             mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl))
                        .value());
    }
 
    if (Units::abs(m_ownship_kinematic_dtg_to_ptp) <=
-       Units::abs(Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().back()))) {
+       Units::abs(Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).along_path_distance))) {
       m_ownship_reference_lookup_index =
-            CoreUtils::FindNearestIndex(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-                                        m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
+            mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).resolved_index;
 
       if (m_ownship_reference_lookup_index == 0) {
          m_ownship_reference_ttg_to_ptp =
@@ -269,10 +255,7 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
          m_ownship_ttg_to_abp =
                m_ownship_reference_ttg_to_ptp - m_ownship_kinematic_achieve_by_calcs.GetTimeToGoToWaypoint();
       } else {
-         m_ownship_reference_ttg_to_ptp = Units::SecondsTime(CoreUtils::LinearlyInterpolate(
-               m_ownship_reference_lookup_index, Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-               m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances(),
-               m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes()));
+         m_ownship_reference_ttg_to_ptp = Units::SecondsTime(mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).time_to_go);
          m_ownship_ttg_to_abp =
                m_ownship_reference_ttg_to_ptp - m_ownship_kinematic_achieve_by_calcs.GetTimeToGoToWaypoint();
       }
@@ -300,41 +283,32 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
 
    ownrefttgtoend = reference_ttg + m_ownship_kinematic_achieve_by_calcs.GetTimeToGoToWaypoint();
 
-   m_reference_precalc_index = CoreUtils::FindNearestIndex(
-         Units::SecondsTime(ownrefttgtoend).value(), m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes());
+   m_reference_precalc_index = mitre::oss::simcore::VerticalPathUtils::GetPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).resolved_index;
 
    if (m_reference_precalc_index >=
-       static_cast<int>(m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes().size() - 1)) {
-      if (Units::SecondsTime(ownrefttgtoend).value() >=
-          m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes().back()) {
+       static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1)) {
+      if (Units::SecondsTime(ownrefttgtoend) >=
+          mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).time_to_go) {
          m_reference_precalc_index =
-               static_cast<int>(m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes().size() - 1);
+               static_cast<int>(mitre::oss::simcore::VerticalPathUtils::GetPathDataCount(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()) - 1);
          reference_distance =
-               Units::MetersLength(-m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances().back());
+               Units::MetersLength(-mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).along_path_distance);
          m_ownship_reference_cas =
-               Units::MetersPerSecondSpeed(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities().back());
+               Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).calibrated_airspeed);
          m_ownship_reference_gs = Units::MetersPerSecondSpeed(
-               m_ownship_kinematic_trajectory_predictor.GetVerticalPathGroundspeeds().back());
+               mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).ground_speed);
          m_ownship_reference_altitude =
-               Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes().back());
+               Units::MetersLength(mitre::oss::simcore::VerticalPathUtils::GetLastPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath()).altitude_msl);
       } else {
          reference_distance = Units::MetersLength(
-               -CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                                               m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                               m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances()));
+               -mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).along_path_distance);
 
          m_ownship_reference_cas = Units::MetersPerSecondSpeed(
-               CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities()));
+               mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).calibrated_airspeed);
          m_ownship_reference_gs = Units::MetersPerSecondSpeed(
-               CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathGroundspeeds()));
+               mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).ground_speed);
          m_ownship_reference_altitude = Units::MetersLength(
-               CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                              m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes()));
+               mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).altitude_msl);
       }
    } else if (m_reference_precalc_index == 0) {
       reference_distance =
@@ -346,22 +320,14 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
 
    } else {
       reference_distance = Units::MetersLength(
-            -CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                                            m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                            m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances()));
+            -mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).along_path_distance);
 
       m_ownship_reference_cas = Units::MetersPerSecondSpeed(
-            CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                                           m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                           m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocities()));
+            mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).calibrated_airspeed);
       m_ownship_reference_gs = Units::MetersPerSecondSpeed(
-            CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                                           m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                           m_ownship_kinematic_trajectory_predictor.GetVerticalPathGroundspeeds()));
+            mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).ground_speed);
       m_ownship_reference_altitude = Units::MetersLength(
-            CoreUtils::LinearlyInterpolate(m_reference_precalc_index, Units::SecondsTime(ownrefttgtoend).value(),
-                                           m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimes(),
-                                           m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudes()));
+            mitre::oss::simcore::VerticalPathUtils::GetInterpolatedPathDataAtTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::SecondsTime(Units::SecondsTime(ownrefttgtoend).value())).altitude_msl);
    }
 
    const Units::Length temp = reference_distance + m_ownship_kinematic_dtg_to_ptp;
@@ -506,8 +472,7 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleMaintainStage(
    }
 
    m_ownship_reference_lookup_index =
-         CoreUtils::FindNearestIndex(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value(),
-                                     m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistances());
+         mitre::oss::simcore::VerticalPathUtils::GetVerticalPathData(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), Units::MetersLength(Units::MetersLength(m_ownship_kinematic_dtg_to_ptp).value())).resolved_index;
 
    if (m_ownship_reference_lookup_index > 0) {
       const Units::Speed nominal_ias = Units::MetersPerSecondSpeed(

--- a/IntervalManagement/IMTimeBasedAchieve.cpp
+++ b/IntervalManagement/IMTimeBasedAchieve.cpp
@@ -194,9 +194,9 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
 
       if (m_target_reference_lookup_index == 0) {
          m_target_ttg_to_end_of_route =
-               Units::SecondsTime(m_target_kinematic_trajectory_predictor.GetVerticalPathTimeByIndex(0));
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).time_to_go;
          m_target_reference_altitude =
-               Units::MetersLength(m_target_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).altitude_msl;
          m_target_reference_ias =
                Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).calibrated_airspeed);
          m_target_reference_gs = Units::MetersPerSecondSpeed(0);
@@ -265,7 +265,7 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
 
       if (m_ownship_reference_lookup_index == 0) {
          m_ownship_reference_ttg_to_ptp =
-               Units::SecondsTime(m_ownship_kinematic_trajectory_predictor.GetVerticalPathTimeByIndex(0));
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).time_to_go;
          m_ownship_ttg_to_abp =
                m_ownship_reference_ttg_to_ptp - m_ownship_kinematic_achieve_by_calcs.GetTimeToGoToWaypoint();
       } else {
@@ -338,11 +338,11 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
       }
    } else if (m_reference_precalc_index == 0) {
       reference_distance =
-            Units::MetersLength(-m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistanceByIndex(0));
+            -mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).along_path_distance;
       m_ownship_reference_cas =
             Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).calibrated_airspeed);
       m_ownship_reference_altitude =
-            Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
+            mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).altitude_msl;
 
    } else {
       reference_distance = Units::MetersLength(
@@ -574,7 +574,7 @@ void IMTimeBasedAchieve::CalculateIas(const Units::Length current_ownship_altitu
                                       const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state) {
    m_im_speed_command_ias = m_speed_limiter.LimitSpeedCommand(
          m_previous_im_speed_command_ias, m_im_speed_command_ias,
-         m_ownship_kinematic_trajectory_predictor.GetVerticalPathCasByIndex(m_ownship_reference_lookup_index),
+         mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed,
          m_ownship_kinematic_dtg_to_abp, m_ownship_kinematic_dtg_to_ptp, current_ownship_altitude,
          three_dof_dynamics_state.flap_configuration);
 

--- a/IntervalManagement/IMTimeBasedAchieve.cpp
+++ b/IntervalManagement/IMTimeBasedAchieve.cpp
@@ -26,6 +26,7 @@
 
 #include "public/CoreUtils.h"
 #include "public/CustomMath.h"
+#include "public/VerticalPathUtils.h"
 
 using namespace std;
 using namespace mitre::oss::simcore;
@@ -197,7 +198,7 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
          m_target_reference_altitude =
                Units::MetersLength(m_target_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
          m_target_reference_ias =
-               Units::MetersPerSecondSpeed(m_target_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(0));
+               Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_target_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).calibrated_airspeed);
          m_target_reference_gs = Units::MetersPerSecondSpeed(0);
       } else {
          m_target_ttg_to_end_of_route = Units::SecondsTime(CoreUtils::LinearlyInterpolate(
@@ -339,7 +340,7 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleAchieveStage(
       reference_distance =
             Units::MetersLength(-m_ownship_kinematic_trajectory_predictor.GetVerticalPathDistanceByIndex(0));
       m_ownship_reference_cas =
-            Units::MetersPerSecondSpeed(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(0));
+            Units::MetersPerSecondSpeed(mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), 0).calibrated_airspeed);
       m_ownship_reference_altitude =
             Units::MetersLength(m_ownship_kinematic_trajectory_predictor.GetVerticalPathAltitudeByIndex(0));
 
@@ -510,7 +511,7 @@ mitre::oss::simcore::Guidance IMTimeBasedAchieve::HandleMaintainStage(
 
    if (m_ownship_reference_lookup_index > 0) {
       const Units::Speed nominal_ias = Units::MetersPerSecondSpeed(
-            m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(m_ownship_reference_lookup_index));
+            mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed);
       m_previous_im_speed_command_ias = m_im_kinematic_time_based_maintain->GetPreviousSpeedCommandIas();
       if (m_previous_im_speed_command_ias != Units::zero() && m_previous_im_speed_command_ias < nominal_ias) {
          guidance_out.m_ias_command = m_previous_im_speed_command_ias;
@@ -605,7 +606,7 @@ void IMTimeBasedAchieve::CalculateMach(const Units::Time reference_ttg, const Un
       estimated_mach = unbounded_estimated_mach;
 
    Units::Speed nominal_ias = Units::MetersPerSecondSpeed(
-         m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(m_ownship_reference_lookup_index));
+         mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(), m_ownship_reference_lookup_index).calibrated_airspeed);
    Units::Speed nominal_tas = m_weather_prediction.getAtmosphere()->CAS2TAS(nominal_ias, current_ownship_altitude);
    BoundedValue<double, 0, 2> nominal_mach(
          Units::MetersPerSecondSpeed(nominal_tas).value() /
@@ -648,11 +649,14 @@ void IMTimeBasedAchieve::RecordInternalObserverMetrics(
           guidance.IsValid()) {
          nm_observer.curr_NM--;
 
-         double lval = m_speed_limiter.LowLimit(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(
-               m_ownship_reference_lookup_index));
-         double hval =
-               m_speed_limiter.HighLimit(m_ownship_kinematic_trajectory_predictor.GetVerticalPathVelocityByIndex(
-                     m_ownship_reference_lookup_index));
+         double lval = Units::MetersPerSecondSpeed(m_speed_limiter.LowLimit(
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(
+                     m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(),
+                     m_ownship_reference_lookup_index).calibrated_airspeed)).value();
+         double hval = Units::MetersPerSecondSpeed(m_speed_limiter.HighLimit(
+               mitre::oss::simcore::VerticalPathUtils::GetPathDataAtIndex(
+                     m_ownship_kinematic_trajectory_predictor.GetVerticalPredictor()->GetVerticalPath(),
+                     m_ownship_reference_lookup_index).calibrated_airspeed)).value();
 
          double ltas = Units::MetersPerSecondSpeed(
                              m_weather_prediction.getAtmosphere()->CAS2TAS(

--- a/IntervalManagement/IMTimeBasedAchieveMutableASG.cpp
+++ b/IntervalManagement/IMTimeBasedAchieveMutableASG.cpp
@@ -72,7 +72,7 @@ bool IMTimeBasedAchieveMutableASG::load(DecodedStream *input) {
 
 void IMTimeBasedAchieveMutableASG::Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                                               const AircraftIntent &ownship_aircraft_intent,
-                                              aaesim::open_source::WeatherPrediction &weather_prediction,
+                                              mitre::oss::simcore::WeatherPrediction &weather_prediction,
                                               std::shared_ptr<TangentPlaneSequence> &position_converter) {
    SetTangentPlaneSequence(nullptr);
    Initialize(ownship_prediction_parameters, ownship_aircraft_intent, weather_prediction);
@@ -80,7 +80,7 @@ void IMTimeBasedAchieveMutableASG::Initialize(const OwnshipPredictionParameters 
 
 void IMTimeBasedAchieveMutableASG::Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                                               const AircraftIntent &ownship_aircraft_intent,
-                                              aaesim::open_source::WeatherPrediction &weather_prediction) {
+                                              mitre::oss::simcore::WeatherPrediction &weather_prediction) {
    IMKinematicAchieve::Initialize(ownship_prediction_parameters, ownship_aircraft_intent, weather_prediction);
 
    if (m_loaded) {
@@ -88,7 +88,7 @@ void IMTimeBasedAchieveMutableASG::Initialize(const OwnshipPredictionParameters 
       // Positive means the ASG is increasing.
       if (m_asg_change_duration > Units::zero()) {
          m_asg_change_increment = ((m_next_assigned_spacing_goal - m_assigned_spacing_goal) / m_asg_change_duration) *
-                                  aaesim::open_source::SimulationTime::GetSimulationTimeStep();
+                                  mitre::oss::simcore::SimulationTime::GetSimulationTimeStep();
       } else {
          // make the change immediate
          m_asg_change_increment = (m_next_assigned_spacing_goal - m_assigned_spacing_goal);
@@ -96,9 +96,9 @@ void IMTimeBasedAchieveMutableASG::Initialize(const OwnshipPredictionParameters 
    }
 }
 
-aaesim::open_source::Guidance IMTimeBasedAchieveMutableASG::Update(
-      const aaesim::open_source::Guidance &previous_im_guidance,
-      const aaesim::open_source::DynamicsState &three_dof_dynamics_state,
+mitre::oss::simcore::Guidance IMTimeBasedAchieveMutableASG::Update(
+      const mitre::oss::simcore::Guidance &previous_im_guidance,
+      const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state,
       const interval_management::open_source::AircraftState &current_ownship_state,
       const interval_management::open_source::AircraftState &current_target_state,
       const vector<interval_management::open_source::AircraftState> &target_adsb_history) {
@@ -112,7 +112,7 @@ aaesim::open_source::Guidance IMTimeBasedAchieveMutableASG::Update(
       m_assigned_spacing_goal += m_asg_change_increment;
    }
 
-   aaesim::open_source::Guidance guidanceout =
+   mitre::oss::simcore::Guidance guidanceout =
          IMTimeBasedAchieve::Update(previous_im_guidance, three_dof_dynamics_state, current_ownship_state,
                                     current_target_state, target_adsb_history);
 

--- a/IntervalManagement/IMUtils.cpp
+++ b/IntervalManagement/IMUtils.cpp
@@ -33,7 +33,7 @@
 #include "public/SimulationTime.h"
 
 using namespace std;
-using namespace aaesim::open_source;
+using namespace mitre::oss::simcore;
 
 log4cplus::Logger IMUtils::m_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("IMUtils"));
 const int IMUtils::UNINITIALIZED_AIRCRAFT_ID = ScenarioUtils::AIRCRAFT_ID_NOT_IN_MAP;
@@ -1153,7 +1153,7 @@ Units::SignedAngle IMUtils::CalculateTrackAngle(const std::list<Units::Angle> &a
 }
 
 interval_management::open_source::AircraftState IMUtils::ConvertToIntervalManagementAircraftState(
-      const aaesim::open_source::AircraftState &aircraft_state) {
+      const mitre::oss::simcore::AircraftState &aircraft_state) {
    interval_management::open_source::AircraftState new_state;
    return new_state.Create(
          aircraft_state.GetUniqueId(), aircraft_state.GetTime(),
@@ -1165,9 +1165,9 @@ interval_management::open_source::AircraftState IMUtils::ConvertToIntervalManage
          aircraft_state.GetSensedTemperature(), aircraft_state.GetPsi());
 }
 
-aaesim::open_source::AircraftState IMUtils::ConvertToAaesimAircraftState(
+mitre::oss::simcore::AircraftState IMUtils::ConvertToAaesimAircraftState(
       const interval_management::open_source::AircraftState &im_state) {
-   return aaesim::open_source::AircraftState::Builder(im_state.GetId(), im_state.GetTimeStamp())
+   return mitre::oss::simcore::AircraftState::Builder(im_state.GetId(), im_state.GetTimeStamp())
          .Position(im_state.GetPositionX(), im_state.GetPositionY())
          ->AltitudeMsl(im_state.GetPositionZ())
          ->GroundSpeed(im_state.GetSpeedXd(), im_state.GetSpeedYd())

--- a/IntervalManagement/InternalObserver.cpp
+++ b/IntervalManagement/InternalObserver.cpp
@@ -29,7 +29,7 @@
 #include "public/StereographicProjection.h"
 
 using namespace std;
-using namespace aaesim::open_source::constants;
+using namespace mitre::oss::simcore::constants;
 using namespace interval_management::open_source;
 
 std::unique_ptr<InternalObserver> InternalObserver::m_instance = nullptr;
@@ -400,7 +400,7 @@ void InternalObserver::processClosestPointMetric() {
    closestPointOutput.clear();
 }
 
-void InternalObserver::addPredictedWind(int id, const aaesim::open_source::WeatherPrediction &weatherPrediction) {
+void InternalObserver::addPredictedWind(int id, const mitre::oss::simcore::WeatherPrediction &weatherPrediction) {
    if (predWinds.empty()) {
       predWinds.push_back(predWindsHeading(weatherPrediction.east_west().GetMaxRow()));
    }
@@ -422,7 +422,7 @@ string InternalObserver::predWindsHeading(int numVals) {
 }
 
 string InternalObserver::predWindsData(int id, int col, const string &field,
-                                       const aaesim::open_source::WindStack &mat) {
+                                       const mitre::oss::simcore::WindStack &mat) {
    string str;
 
    auto buffer_size = 31;
@@ -450,7 +450,7 @@ string InternalObserver::predWindsData(int id, int col, const string &field,
 }
 
 string InternalObserver::predTempData(int id, const string &field,
-                                      const aaesim::open_source::WeatherPrediction &weatherPrediction) {
+                                      const mitre::oss::simcore::WeatherPrediction &weatherPrediction) {
    string str;
 
    char txt[31];
@@ -461,7 +461,7 @@ string InternalObserver::predTempData(int id, const string &field,
    str += ",";
    str += field.c_str();
 
-   const aaesim::open_source::WindStack &mat(weatherPrediction.east_west());
+   const mitre::oss::simcore::WindStack &mat(weatherPrediction.east_west());
    for (int i = 1; i <= mat.GetMaxRow(); i++) {
       Units::Length alt = mat.GetAltitude(i);
       Units::KelvinTemperature temperature = weatherPrediction.GetForecastAtmosphere()->GetTemperature(alt);

--- a/IntervalManagement/MOPSPredictedWindEvaluatorVersion1.cpp
+++ b/IntervalManagement/MOPSPredictedWindEvaluatorVersion1.cpp
@@ -36,12 +36,12 @@ using namespace interval_management::open_source;
 const Units::Angle MOPSPredictedWindEvaluatorVersion1::toleranceAngle(Units::DegreesAngle(15.0));
 const Units::Speed MOPSPredictedWindEvaluatorVersion1::toleranceSpeed(Units::KnotsSpeed(10.0));
 
-std::shared_ptr<aaesim::open_source::PredictedWindEvaluator> MOPSPredictedWindEvaluatorVersion1::mInstance;
+std::shared_ptr<mitre::oss::simcore::PredictedWindEvaluator> MOPSPredictedWindEvaluatorVersion1::mInstance;
 
-const std::shared_ptr<aaesim::open_source::PredictedWindEvaluator> &MOPSPredictedWindEvaluatorVersion1::GetInstance() {
+const std::shared_ptr<mitre::oss::simcore::PredictedWindEvaluator> &MOPSPredictedWindEvaluatorVersion1::GetInstance() {
    if (!mInstance) {
       mInstance =
-            std::shared_ptr<aaesim::open_source::PredictedWindEvaluator>(new MOPSPredictedWindEvaluatorVersion1());
+            std::shared_ptr<mitre::oss::simcore::PredictedWindEvaluator>(new MOPSPredictedWindEvaluatorVersion1());
    }
    return mInstance;
 }
@@ -51,7 +51,7 @@ MOPSPredictedWindEvaluatorVersion1::MOPSPredictedWindEvaluatorVersion1() = defau
 MOPSPredictedWindEvaluatorVersion1::~MOPSPredictedWindEvaluatorVersion1() = default;
 
 bool MOPSPredictedWindEvaluatorVersion1::ArePredictedWindsAccurate(
-      const aaesim::open_source::AircraftState &state, const aaesim::open_source::WeatherPrediction &weatherPrediction,
+      const mitre::oss::simcore::AircraftState &state, const mitre::oss::simcore::WeatherPrediction &weatherPrediction,
       const Units::Speed reference_cas, const Units::Length reference_altitude,
       const std::shared_ptr<Atmosphere> &sensed_atmosphere) const {
    Units::MetersPerSecondSpeed windeastcomp, windnorthcomp;

--- a/IntervalManagement/MOPSPredictedWindEvaluatorVersion2.cpp
+++ b/IntervalManagement/MOPSPredictedWindEvaluatorVersion2.cpp
@@ -30,12 +30,12 @@ log4cplus::Logger MOPSPredictedWindEvaluatorVersion2::m_logger =
 
 Units::KnotsSpeed MOPSPredictedWindEvaluatorVersion2::MAX_PERMITTED_GROUNDSPEED_ERROR(8);
 
-std::shared_ptr<aaesim::open_source::PredictedWindEvaluator> MOPSPredictedWindEvaluatorVersion2::mInstance;
+std::shared_ptr<mitre::oss::simcore::PredictedWindEvaluator> MOPSPredictedWindEvaluatorVersion2::mInstance;
 
-const std::shared_ptr<aaesim::open_source::PredictedWindEvaluator> &MOPSPredictedWindEvaluatorVersion2::GetInstance() {
+const std::shared_ptr<mitre::oss::simcore::PredictedWindEvaluator> &MOPSPredictedWindEvaluatorVersion2::GetInstance() {
    if (!mInstance) {
       mInstance =
-            std::shared_ptr<aaesim::open_source::PredictedWindEvaluator>(new MOPSPredictedWindEvaluatorVersion2());
+            std::shared_ptr<mitre::oss::simcore::PredictedWindEvaluator>(new MOPSPredictedWindEvaluatorVersion2());
    }
    return mInstance;
 }
@@ -45,7 +45,7 @@ MOPSPredictedWindEvaluatorVersion2::MOPSPredictedWindEvaluatorVersion2() = defau
 MOPSPredictedWindEvaluatorVersion2::~MOPSPredictedWindEvaluatorVersion2() = default;
 
 bool MOPSPredictedWindEvaluatorVersion2::ArePredictedWindsAccurate(
-      const aaesim::open_source::AircraftState &state, const aaesim::open_source::WeatherPrediction &weather_prediction,
+      const mitre::oss::simcore::AircraftState &state, const mitre::oss::simcore::WeatherPrediction &weather_prediction,
       const Units::Speed reference_cas, const Units::Length reference_altitude,
       const std::shared_ptr<Atmosphere> &sensed_atmosphere) const {
    Units::FeetLength true_altitude{state.GetAltitudeMsl()};
@@ -107,7 +107,7 @@ void MOPSPredictedWindEvaluatorVersion2::LogWindDisagreeMetaData(
       const Units::Length reference_altitude, const Units::FeetLength true_altitude, const Units::Speed reference_cas,
       const Units::KnotsSpeed tas1, const Units::KnotsSpeed tas2, const Units::KnotsSpeed gs1,
       const Units::KnotsSpeed gs2, const Units::Speed predicted_wind_x, const Units::Speed predicted_wind_y,
-      const aaesim::open_source::AircraftState &state) {
+      const mitre::oss::simcore::AircraftState &state) {
    LOG4CPLUS_TRACE(
          m_logger,
          "Winds inaccurate:" << std::endl

--- a/IntervalManagement/MergePointMetric.cpp
+++ b/IntervalManagement/MergePointMetric.cpp
@@ -24,6 +24,8 @@
 #include <utility>
 
 #include "public/AircraftCalculations.h"
+#include "imalgs/IMUtils.h"
+#include "imalgs/FIMAircraftIntent.h"
 
 using namespace std;
 using namespace interval_management::open_source;
@@ -42,8 +44,10 @@ void MergePointMetric::determineMergePoint(const AircraftIntent &imintent, const
    // imintent:intent of IM aircraft containing the list of waypoints.
    // targintent:intent of target aircraft containing the list of waypoints.
 
-   m_im_ac_id = imintent.GetId();
-   m_target_ac_id = targintent.GetId();
+   const auto *ownship_intent = dynamic_cast<const FIMAircraftIntent *>(&imintent);
+   const auto *target_intent = dynamic_cast<const FIMAircraftIntent *>(&targintent);
+   m_im_ac_id = ownship_intent ? ownship_intent->GetId() : IMUtils::UNINITIALIZED_AIRCRAFT_ID;
+   m_target_ac_id = target_intent ? target_intent->GetId() : IMUtils::UNINITIALIZED_AIRCRAFT_ID;
 
    // overwrite these if merge point is found
    mReportMetrics = false;
@@ -56,13 +60,12 @@ void MergePointMetric::determineMergePoint(const AircraftIntent &imintent, const
       LOG4CPLUS_TRACE(logger,
                       "Target ID matches own for acid " << m_im_ac_id << ". No merge metrics will be reported.");
    } else if (index == -1) {
-      LOG4CPLUS_TRACE(logger, "No merge point found for im acid " << imintent.GetId() << " and target acid "
-                                                                  << targintent.GetId()
+      LOG4CPLUS_TRACE(logger, "No merge point found for the current ownship and target intents"
                                                                   << ". No merge metrics will be reported.");
    } else {
       mMergePointName = imintent.GetWaypointName(index);
-      mMergePointX = imintent.GetWaypointX(index);
-      mMergePointY = imintent.GetWaypointY(index);
+      mMergePointX = imintent.GetRouteData().m_x[index];
+      mMergePointY = imintent.GetRouteData().m_y[index];
       mReportMetrics = true;
    }
 }

--- a/IntervalManagement/MergePointMetric.cpp
+++ b/IntervalManagement/MergePointMetric.cpp
@@ -91,12 +91,12 @@ void MergePointMetric::update(double imXNew, double imYNew, double targXNew, dou
 
       m_im_x_ft = imXNew;
       m_im_y_ft = imYNew;
-      mIMDist = aaesim::open_source::AircraftCalculations::PtToPtDist(
+      mIMDist = mitre::oss::simcore::AircraftCalculations::PtToPtDist(
             mMergePointX, mMergePointY, Units::FeetLength(m_im_x_ft), Units::FeetLength(m_im_y_ft));
 
       m_targ_x_ft = targXNew;
       m_targ_y_ft = targYNew;
-      mMergeDist = aaesim::open_source::AircraftCalculations::PtToPtDist(
+      mMergeDist = mitre::oss::simcore::AircraftCalculations::PtToPtDist(
             Units::FeetLength(m_im_x_ft), Units::FeetLength(m_im_y_ft), Units::FeetLength(m_targ_x_ft),
             Units::FeetLength(m_targ_y_ft));
    }
@@ -126,7 +126,7 @@ bool MergePointMetric::newPointCloser(double x, double y) {
    // returns true if the new closer to the merge point.
    //         else false.
 
-   return (aaesim::open_source::AircraftCalculations::PtToPtDist(mMergePointX, mMergePointY, Units::FeetLength(x),
+   return (mitre::oss::simcore::AircraftCalculations::PtToPtDist(mMergePointX, mMergePointY, Units::FeetLength(x),
                                                                  Units::FeetLength(y)) < mIMDist);
 }
 

--- a/IntervalManagement/MergePointMetric.cpp
+++ b/IntervalManagement/MergePointMetric.cpp
@@ -63,7 +63,12 @@ void MergePointMetric::determineMergePoint(const AircraftIntent &imintent, const
       LOG4CPLUS_TRACE(logger, "No merge point found for the current ownship and target intents"
                                                                   << ". No merge metrics will be reported.");
    } else {
-      mMergePointName = imintent.GetWaypointName(index);
+      const auto merge_point_name = imintent.GetWaypointName(index);
+      if (!merge_point_name) {
+         LOG4CPLUS_WARN(logger, "Merge point index " << index << " is not available. No merge metrics will be reported.");
+         return;
+      }
+      mMergePointName = *merge_point_name;
       mMergePointX = imintent.GetRouteData().m_x[index];
       mMergePointY = imintent.GetRouteData().m_y[index];
       mReportMetrics = true;

--- a/IntervalManagement/PredictionFileKinematic.cpp
+++ b/IntervalManagement/PredictionFileKinematic.cpp
@@ -102,7 +102,7 @@ void PredictionFileKinematic::Finish() {
 
 void PredictionFileKinematic::Gather(
       const int iteration, const Units::Time simulation_time, std::string aircraft_id,
-      const std::shared_ptr<const aaesim::open_source::FlightDeckApplication> &flightdeck_application) {
+      const std::shared_ptr<const mitre::oss::simcore::FlightDeckApplication> &flightdeck_application) {
    const bool is_im_application =
          CoreUtils::InstanceOf<interval_management::open_source::FIMAlgorithmAdapter>(flightdeck_application.get());
    if (is_im_application) {

--- a/IntervalManagement/WaypointLoader.cpp
+++ b/IntervalManagement/WaypointLoader.cpp
@@ -26,6 +26,8 @@
 namespace interval_management {
 namespace loaders {
 
+using namespace mitre::oss::simcore;
+
 bool WaypointLoader::load(DecodedStream *input) {
    set_stream(input);
 

--- a/docs/entry_points.md
+++ b/docs/entry_points.md
@@ -66,8 +66,4 @@ This output can also be accessed via a simple getter exposed by [`IMAlgorithm`](
 
 We've noticed that the `Units::Speed` object sometimes truncates bits when converting from meters-per-second to knots. The result is that the above call to GetImSpeedCommandIas() can sometimes give a value very near to an integer IAS value, but not quite (e.g. 269.9999999 rather than 270.0). This can look odd on a human-interface display. There are multiple work-arounds to this problem, but ours has been to also provide an integer accessor for the IM Speed. It's in the [Guidance](https://github.com/mitre/FMACM/blob/d8156ca28e9f9073c933ea5776d9bde91f003b0c/include/public/Guidance.h#L38) object and looks like this:
 
-```c++
-int GetIasCommandIntegerKnots() const;
-```
-
 This call is implemented such that it is guaranteed to return a clean value appropriate for human-interface displays.

--- a/include/imalgs/AchieveObserver.h
+++ b/include/imalgs/AchieveObserver.h
@@ -26,6 +26,7 @@
 
 namespace interval_management {
 namespace open_source {
+
 class AchieveObserver final {
   public:
    AchieveObserver();

--- a/include/imalgs/AchievePointCalcs.h
+++ b/include/imalgs/AchievePointCalcs.h
@@ -40,16 +40,19 @@
 
 namespace interval_management {
 namespace open_source {
+
+using namespace mitre::oss::simcore;
+
 class AchievePointCalcs final {
   public:
    AchievePointCalcs();
 
    AchievePointCalcs(const std::string &waypoint, const AircraftIntent &intent, const VerticalPath &vpath,
-                     const std::vector<aaesim::open_source::HorizontalPath> &htraj);
+                     const std::vector<mitre::oss::simcore::HorizontalPath> &htraj);
 
    /** Constructor for target, with enough info to calculate TRP */
    AchievePointCalcs(const std::string &waypoint, const AircraftIntent &intent, const VerticalPath &vpath,
-                     const std::vector<aaesim::open_source::HorizontalPath> &htraj,
+                     const std::vector<mitre::oss::simcore::HorizontalPath> &htraj,
                      const AchievePointCalcs &ownship_calcs, const AircraftIntent &ownship_intent,
                      const std::shared_ptr<TangentPlaneSequence> &position_converter);
 
@@ -97,7 +100,7 @@ class AchievePointCalcs final {
    static void ComputeDefaultTRP(const AchievePointCalcs &ownship_calcs, const AircraftIntent &ownship_intent,
                                  const AircraftIntent &target_intent,
                                  const std::shared_ptr<TangentPlaneSequence> &position_converter,
-                                 const std::vector<aaesim::open_source::HorizontalPath> &target_horizontal_path,
+                                 const std::vector<mitre::oss::simcore::HorizontalPath> &target_horizontal_path,
                                  Waypoint &traffic_reference_point, Units::Length &waypoint_x,
                                  Units::Length &waypoint_y, size_t &waypoint_index_in_target_intent);
 
@@ -118,12 +121,12 @@ class AchievePointCalcs final {
    Units::Time m_time_to_go_to_waypoint;
    Units::Time m_crossing_time;
    bool m_waypoint_is_set;
-   std::vector<aaesim::open_source::HorizontalPath> m_horizontal_path;
+   std::vector<mitre::oss::simcore::HorizontalPath> m_horizontal_path;
 
   private:
    static log4cplus::Logger m_logger;
 
-   aaesim::open_source::AlongPathDistanceCalculator m_distance_calculator;
+   mitre::oss::simcore::AlongPathDistanceCalculator m_distance_calculator;
 };
 
 inline const bool AchievePointCalcs::HasWaypoint() const { return m_waypoint_is_set; }

--- a/include/imalgs/AchievePointCalcs.h
+++ b/include/imalgs/AchievePointCalcs.h
@@ -33,6 +33,7 @@
 
 #include "imalgs/AircraftState.h"
 #include "public/AircraftIntent.h"
+#include "public/TangentPlaneSequence.h"
 #include "public/AlongPathDistanceCalculator.h"
 #include "public/HorizontalPath.h"
 #include "public/VerticalPath.h"

--- a/include/imalgs/AircraftIntentLoader.h
+++ b/include/imalgs/AircraftIntentLoader.h
@@ -23,7 +23,7 @@
 #include <log4cplus/logger.h>
 #include <log4cplus/loggingmacros.h>
 
-#include "public/DefaultAircraftIntent.h"
+#include "imalgs/FIMAircraftIntent.h"
 
 namespace interval_management {
 namespace loaders {
@@ -35,23 +35,20 @@ class AircraftIntentLoader final : public LoggingLoadable {
 
    bool load(DecodedStream *input) override;
 
-   const AircraftIntent &BuildAircraftIntent() const;
-   AircraftIntent &GetAircraftIntent();
-   const AircraftIntent &GetAircraftIntent() const;
+   const open_source::FIMAircraftIntent &BuildAircraftIntent() const;
+   const open_source::FIMAircraftIntent &GetAircraftIntent() const;
    bool IsLoaded() const;
 
   private:
    static inline log4cplus::Logger logger_{log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("AircraftIntentLoader"))};
 
-   DefaultAircraftIntent aircraft_intent_{};
+   open_source::FIMAircraftIntent aircraft_intent_{};
    bool is_loaded_{false};
 };
 
-inline const AircraftIntent &AircraftIntentLoader::BuildAircraftIntent() const { return aircraft_intent_; }
+inline const open_source::FIMAircraftIntent &AircraftIntentLoader::BuildAircraftIntent() const { return aircraft_intent_; }
 
-inline AircraftIntent &AircraftIntentLoader::GetAircraftIntent() { return aircraft_intent_; }
-
-inline const AircraftIntent &AircraftIntentLoader::GetAircraftIntent() const { return aircraft_intent_; }
+inline const open_source::FIMAircraftIntent &AircraftIntentLoader::GetAircraftIntent() const { return aircraft_intent_; }
 
 inline bool AircraftIntentLoader::IsLoaded() const { return is_loaded_; }
 

--- a/include/imalgs/AircraftIntentLoader.h
+++ b/include/imalgs/AircraftIntentLoader.h
@@ -23,7 +23,7 @@
 #include <log4cplus/logger.h>
 #include <log4cplus/loggingmacros.h>
 
-#include "public/AircraftIntent.h"
+#include "public/DefaultAircraftIntent.h"
 
 namespace interval_management {
 namespace loaders {
@@ -43,7 +43,7 @@ class AircraftIntentLoader final : public LoggingLoadable {
   private:
    static inline log4cplus::Logger logger_{log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("AircraftIntentLoader"))};
 
-   AircraftIntent aircraft_intent_{};
+   DefaultAircraftIntent aircraft_intent_{};
    bool is_loaded_{false};
 };
 

--- a/include/imalgs/AircraftState.h
+++ b/include/imalgs/AircraftState.h
@@ -31,6 +31,9 @@
 
 namespace interval_management {
 namespace open_source {
+
+using namespace mitre::oss::simcore;
+
 class AircraftState final {
   public:
    AircraftState();

--- a/include/imalgs/ClosestPointMetric.h
+++ b/include/imalgs/ClosestPointMetric.h
@@ -23,6 +23,7 @@
 
 namespace interval_management {
 namespace open_source {
+
 class ClosestPointMetric final {
   public:
    ClosestPointMetric();

--- a/include/imalgs/CrossTrackObserver.h
+++ b/include/imalgs/CrossTrackObserver.h
@@ -21,6 +21,7 @@
 
 namespace interval_management {
 namespace open_source {
+
 class CrossTrackObserver final {
   public:
    CrossTrackObserver(void);

--- a/include/imalgs/FIMAircraftIntent.h
+++ b/include/imalgs/FIMAircraftIntent.h
@@ -6,12 +6,16 @@
 
 #pragma once
 
+#include <algorithm>
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "public/DefaultAircraftIntent.h"
 #include "public/AircraftIntentUtils.h"
 #include "public/ScenarioUtils.h"
+#include "utility/BoundedValue.h"
 
 namespace interval_management::open_source {
 
@@ -46,7 +50,26 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
          intent_.InsertPairAtIndex(name, x, y, index);
          return *this;
       }
-      Builder &UpdateWaypoint(const Waypoint &waypoint) { intent_.UpdateWaypoint(waypoint); return *this; }
+      Builder &UpdateWaypoint(const Waypoint &waypoint) {
+         auto updated_waypoints = intent_.GetWaypoints();
+         const auto matching_waypoints = std::count_if(
+               updated_waypoints.cbegin(), updated_waypoints.cend(),
+               [&waypoint](const Waypoint &existing_waypoint) { return existing_waypoint.GetName() == waypoint.GetName(); });
+         if (matching_waypoints != 1) {
+            throw std::runtime_error("Expected exactly one waypoint with the supplied name.");
+         }
+         std::replace_if(updated_waypoints.begin(), updated_waypoints.end(),
+                         [&waypoint](const Waypoint &existing_waypoint) {
+                            return existing_waypoint.GetName() == waypoint.GetName();
+                         },
+                         waypoint);
+         intent_ = *aaesim::open_source::DefaultAircraftIntent::Builder()
+                            .SetDescentWaypoints(updated_waypoints)
+                            .SetPlannedCruiseMach(BoundedValue<double, 0, 1>(intent_.GetPlannedCruiseMach()))
+                            .SetPlannedCruiseAltitude(intent_.GetPlannedCruiseAltitude())
+                            .Build();
+         return *this;
+      }
       Builder &LoadWaypoints(const std::vector<Waypoint> &ascent, const std::vector<Waypoint> &cruise,
                              const std::vector<Waypoint> &descent) {
          intent_ = *aaesim::open_source::DefaultAircraftIntent::Builder()

--- a/include/imalgs/FIMAircraftIntent.h
+++ b/include/imalgs/FIMAircraftIntent.h
@@ -49,7 +49,11 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
       Builder &UpdateWaypoint(const Waypoint &waypoint) { intent_.UpdateWaypoint(waypoint); return *this; }
       Builder &LoadWaypoints(const std::vector<Waypoint> &ascent, const std::vector<Waypoint> &cruise,
                              const std::vector<Waypoint> &descent) {
-         intent_.LoadWaypoints(ascent, cruise, descent);
+         intent_ = *aaesim::open_source::DefaultAircraftIntent::Builder()
+                            .SetAscentWaypoints(ascent)
+                            .SetCruiseWaypoints(cruise)
+                            .SetDescentWaypoints(descent)
+                            .Build();
          return *this;
       }
       FIMAircraftIntent Build() const { return FIMAircraftIntent(intent_, id_); }

--- a/include/imalgs/FIMAircraftIntent.h
+++ b/include/imalgs/FIMAircraftIntent.h
@@ -68,12 +68,14 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
             .SetId(intent.id_).Build();
    }
 
-   const Waypoint &GetWaypoint(unsigned int i) const override { return intent_.GetWaypoint(i); }
+   std::optional<Waypoint> GetWaypoint(unsigned int i) const override { return intent_.GetWaypoint(i); }
    const std::vector<Waypoint> &GetWaypoints() const override { return intent_.GetWaypoints(); }
-   const std::string &GetWaypointName(unsigned int i) const override { return intent_.GetWaypointName(i); }
+   std::optional<std::string> GetWaypointName(unsigned int i) const override { return intent_.GetWaypointName(i); }
    Units::MetersLength GetPlannedCruiseAltitude() const override { return intent_.GetPlannedCruiseAltitude(); }
    const RouteData &GetRouteData() const override { return intent_.GetRouteData(); }
-   int GetWaypointIndexByName(const std::string &name) const override { return intent_.GetWaypointIndexByName(name); }
+   std::optional<unsigned int> GetWaypointIndexByName(const std::string &name) const override {
+      return intent_.GetWaypointIndexByName(name);
+   }
    std::pair<int, int> FindCommonWaypoint(const AircraftIntent &intent) const override {
       return intent_.FindCommonWaypoint(intent);
    }

--- a/include/imalgs/FIMAircraftIntent.h
+++ b/include/imalgs/FIMAircraftIntent.h
@@ -29,11 +29,11 @@ class FIMAircraftIntent final : public mitre::oss::simcore::AircraftIntent {
       Builder() = default;
       explicit Builder(const mitre::oss::simcore::DefaultAircraftIntent &intent) : intent_(intent) {}
       explicit Builder(const std::shared_ptr<const mitre::oss::simcore::AircraftIntent> &intent)
-         : intent_(*mitre::oss::simcore::DefaultAircraftIntent::Builder(*intent).Build()) {}
+         : intent_(*mitre::oss::simcore::DefaultAircraftIntent::Builder().CopyFrom(*intent).Build()) {}
       explicit Builder(const std::shared_ptr<mitre::oss::simcore::AircraftIntent> &intent)
-         : intent_(*mitre::oss::simcore::DefaultAircraftIntent::Builder(*intent).Build()) {}
+         : intent_(*mitre::oss::simcore::DefaultAircraftIntent::Builder().CopyFrom(*intent).Build()) {}
       explicit Builder(const mitre::oss::simcore::AircraftIntent &intent)
-         : intent_(*mitre::oss::simcore::DefaultAircraftIntent::Builder(intent).Build()) {}
+         : intent_(*mitre::oss::simcore::DefaultAircraftIntent::Builder().CopyFrom(intent).Build()) {}
 
       Builder &SetId(int id) { id_ = id; return *this; }
       Builder &SetAircraftId(const std::string &aircraft_id) {
@@ -41,13 +41,13 @@ class FIMAircraftIntent final : public mitre::oss::simcore::AircraftIntent {
          return *this;
       }
       Builder &SetPlannedCruiseAltitude(Units::Length altitude) {
-         intent_ = *mitre::oss::simcore::DefaultAircraftIntent::Builder(intent_)
+         intent_ = *mitre::oss::simcore::DefaultAircraftIntent::Builder().CopyFrom(intent_)
                             .SetPlannedCruiseAltitude(altitude)
                             .Build();
          return *this;
       }
       Builder &SetPlannedCruiseMach(BoundedValue<double, 0, 1> mach) {
-         intent_ = *mitre::oss::simcore::DefaultAircraftIntent::Builder(intent_)
+         intent_ = *mitre::oss::simcore::DefaultAircraftIntent::Builder().CopyFrom(intent_)
                             .SetPlannedCruiseMach(mach)
                             .Build();
          return *this;

--- a/include/imalgs/FIMAircraftIntent.h
+++ b/include/imalgs/FIMAircraftIntent.h
@@ -15,6 +15,7 @@
 #include "public/DefaultAircraftIntent.h"
 #include "public/AircraftIntentUtils.h"
 #include "public/ScenarioUtils.h"
+#include "public/SingleTangentPlaneSequence.h"
 #include "utility/BoundedValue.h"
 
 namespace interval_management::open_source {
@@ -50,12 +51,49 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
          return *this;
       }
       Builder &InsertWaypointAtIndex(const Waypoint &waypoint, int index) {
-         intent_.InsertWaypointAtIndex(waypoint, index);
+         if (index < 0 || static_cast<unsigned int>(index) > intent_.GetNumberOfWaypoints()) {
+            throw std::out_of_range("Waypoint insertion index is outside the intent route");
+         }
+
+         auto ascent = intent_.GetAscentWaypoints();
+         auto cruise = intent_.GetCruiseWaypoints();
+         auto descent = intent_.GetDescentWaypoints();
+         const auto insertion_index = static_cast<std::size_t>(index);
+         if (insertion_index < ascent.size()) {
+            ascent.insert(ascent.begin() + index, waypoint);
+         } else if (insertion_index < ascent.size() + cruise.size()) {
+            cruise.insert(cruise.begin() + index - static_cast<int>(ascent.size()), waypoint);
+         } else {
+            descent.insert(descent.begin() + index - static_cast<int>(ascent.size() + cruise.size()), waypoint);
+         }
+         RebuildIntent(ascent, cruise, descent);
          return *this;
       }
       Builder &InsertPairAtIndex(const std::string &name, Units::Length x, Units::Length y, int index) {
-         intent_.InsertPairAtIndex(name, x, y, index);
-         return *this;
+         const auto &waypoints = intent_.GetWaypoints();
+         if (waypoints.empty() || index < 0 || static_cast<unsigned int>(index) > waypoints.size()) {
+            throw std::out_of_range("Pair insertion index is outside the intent route");
+         }
+
+         SingleTangentPlaneSequence position_converter(waypoints);
+         EarthModel::LocalPositionEnu local_position{};
+         local_position.x = x;
+         local_position.y = y;
+         local_position.z = Units::ZERO_LENGTH;
+         EarthModel::GeodeticPosition geodetic_position{};
+         position_converter.ConvertLocalToGeodetic(local_position, geodetic_position);
+
+         Waypoint waypoint{};
+         waypoint.SetRfTurnArcRadius(Units::ZERO_LENGTH);
+         waypoint.SetWaypointLatLon(geodetic_position.latitude, geodetic_position.longitude);
+         waypoint.SetName(name);
+         const auto &previous_waypoint = waypoints[index == 0 ? 0 : index - 1];
+         const auto &next_waypoint = waypoints[index == static_cast<int>(waypoints.size()) ? waypoints.size() - 1 : index];
+         waypoint.SetAltitudeConstraintHigh(previous_waypoint.GetAltitudeConstraintHigh());
+         waypoint.SetSpeedConstraintHigh(previous_waypoint.GetSpeedConstraintHigh());
+         waypoint.SetAltitudeConstraintLow(next_waypoint.GetAltitudeConstraintLow());
+         waypoint.SetSpeedConstraintLow(next_waypoint.GetSpeedConstraintLow());
+         return InsertWaypointAtIndex(waypoint, index);
       }
       Builder &UpdateWaypoint(const Waypoint &waypoint) {
          auto updated_waypoints = intent_.GetWaypoints();
@@ -89,6 +127,17 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
       FIMAircraftIntent Build() const { return FIMAircraftIntent(intent_, id_); }
 
     private:
+      void RebuildIntent(const std::vector<Waypoint> &ascent, const std::vector<Waypoint> &cruise,
+                         const std::vector<Waypoint> &descent) {
+         intent_ = *aaesim::open_source::DefaultAircraftIntent::Builder()
+                            .SetAscentWaypoints(ascent)
+                            .SetCruiseWaypoints(cruise)
+                            .SetDescentWaypoints(descent)
+                            .SetPlannedCruiseMach(BoundedValue<double, 0, 1>(intent_.GetPlannedCruiseMach()))
+                            .SetPlannedCruiseAltitude(intent_.GetPlannedCruiseAltitude())
+                            .Build();
+      }
+
       aaesim::open_source::DefaultAircraftIntent intent_{};
       int id_{aaesim::open_source::ScenarioUtils::AIRCRAFT_ID_NOT_IN_MAP};
    };

--- a/include/imalgs/FIMAircraftIntent.h
+++ b/include/imalgs/FIMAircraftIntent.h
@@ -20,32 +20,34 @@
 
 namespace interval_management::open_source {
 
-class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
+using namespace mitre::oss::simcore;
+
+class FIMAircraftIntent final : public mitre::oss::simcore::AircraftIntent {
  public:
    class Builder final {
     public:
       Builder() = default;
-      explicit Builder(const aaesim::open_source::DefaultAircraftIntent &intent) : intent_(intent) {}
-      explicit Builder(const std::shared_ptr<const aaesim::open_source::AircraftIntent> &intent)
-         : intent_(*aaesim::open_source::DefaultAircraftIntent::Builder(*intent).Build()) {}
-      explicit Builder(const std::shared_ptr<aaesim::open_source::AircraftIntent> &intent)
-         : intent_(*aaesim::open_source::DefaultAircraftIntent::Builder(*intent).Build()) {}
-      explicit Builder(const aaesim::open_source::AircraftIntent &intent)
-         : intent_(*aaesim::open_source::DefaultAircraftIntent::Builder(intent).Build()) {}
+      explicit Builder(const mitre::oss::simcore::DefaultAircraftIntent &intent) : intent_(intent) {}
+      explicit Builder(const std::shared_ptr<const mitre::oss::simcore::AircraftIntent> &intent)
+         : intent_(*mitre::oss::simcore::DefaultAircraftIntent::Builder(*intent).Build()) {}
+      explicit Builder(const std::shared_ptr<mitre::oss::simcore::AircraftIntent> &intent)
+         : intent_(*mitre::oss::simcore::DefaultAircraftIntent::Builder(*intent).Build()) {}
+      explicit Builder(const mitre::oss::simcore::AircraftIntent &intent)
+         : intent_(*mitre::oss::simcore::DefaultAircraftIntent::Builder(intent).Build()) {}
 
       Builder &SetId(int id) { id_ = id; return *this; }
       Builder &SetAircraftId(const std::string &aircraft_id) {
-         id_ = aaesim::open_source::ScenarioUtils::GetUniqueIdForAircraftId(aircraft_id);
+         id_ = mitre::oss::simcore::ScenarioUtils::GetUniqueIdForAircraftId(aircraft_id);
          return *this;
       }
       Builder &SetPlannedCruiseAltitude(Units::Length altitude) {
-         intent_ = *aaesim::open_source::DefaultAircraftIntent::Builder(intent_)
+         intent_ = *mitre::oss::simcore::DefaultAircraftIntent::Builder(intent_)
                             .SetPlannedCruiseAltitude(altitude)
                             .Build();
          return *this;
       }
       Builder &SetPlannedCruiseMach(BoundedValue<double, 0, 1> mach) {
-         intent_ = *aaesim::open_source::DefaultAircraftIntent::Builder(intent_)
+         intent_ = *mitre::oss::simcore::DefaultAircraftIntent::Builder(intent_)
                             .SetPlannedCruiseMach(mach)
                             .Build();
          return *this;
@@ -108,7 +110,7 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
                             return existing_waypoint.GetName() == waypoint.GetName();
                          },
                          waypoint);
-         intent_ = *aaesim::open_source::DefaultAircraftIntent::Builder()
+         intent_ = *mitre::oss::simcore::DefaultAircraftIntent::Builder()
                             .SetDescentWaypoints(updated_waypoints)
                             .SetPlannedCruiseMach(BoundedValue<double, 0, 1>(intent_.GetPlannedCruiseMach()))
                             .SetPlannedCruiseAltitude(intent_.GetPlannedCruiseAltitude())
@@ -117,7 +119,7 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
       }
       Builder &LoadWaypoints(const std::vector<Waypoint> &ascent, const std::vector<Waypoint> &cruise,
                              const std::vector<Waypoint> &descent) {
-         intent_ = *aaesim::open_source::DefaultAircraftIntent::Builder()
+         intent_ = *mitre::oss::simcore::DefaultAircraftIntent::Builder()
                             .SetAscentWaypoints(ascent)
                             .SetCruiseWaypoints(cruise)
                             .SetDescentWaypoints(descent)
@@ -129,7 +131,7 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
     private:
       void RebuildIntent(const std::vector<Waypoint> &ascent, const std::vector<Waypoint> &cruise,
                          const std::vector<Waypoint> &descent) {
-         intent_ = *aaesim::open_source::DefaultAircraftIntent::Builder()
+         intent_ = *mitre::oss::simcore::DefaultAircraftIntent::Builder()
                             .SetAscentWaypoints(ascent)
                             .SetCruiseWaypoints(cruise)
                             .SetDescentWaypoints(descent)
@@ -138,8 +140,8 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
                             .Build();
       }
 
-      aaesim::open_source::DefaultAircraftIntent intent_{};
-      int id_{aaesim::open_source::ScenarioUtils::AIRCRAFT_ID_NOT_IN_MAP};
+      mitre::oss::simcore::DefaultAircraftIntent intent_{};
+      int id_{mitre::oss::simcore::ScenarioUtils::AIRCRAFT_ID_NOT_IN_MAP};
    };
 
    FIMAircraftIntent() = default;
@@ -147,7 +149,7 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
 
    static FIMAircraftIntent CopyAndTrimAfterNamedWaypoint(const FIMAircraftIntent &intent,
                                                            const std::string &waypoint_name) {
-      return Builder(aaesim::open_source::AircraftIntentUtils::CopyAndTrimAfterNamedWaypoint(intent, waypoint_name))
+      return Builder(mitre::oss::simcore::AircraftIntentUtils::CopyAndTrimAfterNamedWaypoint(intent, waypoint_name))
             .SetId(intent.id_).Build();
    }
 
@@ -174,10 +176,10 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
    Units::MetersLength GetWaypointY(unsigned int index) const { return intent_.GetWaypointY(index); }
 
  private:
-   FIMAircraftIntent(const aaesim::open_source::DefaultAircraftIntent &intent, int id) : intent_(intent), id_(id) {}
+   FIMAircraftIntent(const mitre::oss::simcore::DefaultAircraftIntent &intent, int id) : intent_(intent), id_(id) {}
 
-   aaesim::open_source::DefaultAircraftIntent intent_{};
-   int id_{aaesim::open_source::ScenarioUtils::AIRCRAFT_ID_NOT_IN_MAP};
+   mitre::oss::simcore::DefaultAircraftIntent intent_{};
+   int id_{mitre::oss::simcore::ScenarioUtils::AIRCRAFT_ID_NOT_IN_MAP};
 };
 
 }  // namespace interval_management::open_source

--- a/include/imalgs/FIMAircraftIntent.h
+++ b/include/imalgs/FIMAircraftIntent.h
@@ -169,7 +169,7 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
    double GetPlannedCruiseMach() const override { return intent_.GetPlannedCruiseMach(); }
    bool ContainsWaypointName(const std::string &name) const override { return intent_.ContainsWaypointName(name); }
 
-   bool IsLoaded() const { return intent_.IsLoaded(); }
+   bool IsLoaded() const { return GetNumberOfWaypoints() > 0; }
    Units::MetersLength GetWaypointX(unsigned int index) const { return intent_.GetWaypointX(index); }
    Units::MetersLength GetWaypointY(unsigned int index) const { return intent_.GetWaypointY(index); }
 

--- a/include/imalgs/FIMAircraftIntent.h
+++ b/include/imalgs/FIMAircraftIntent.h
@@ -37,9 +37,16 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
          id_ = aaesim::open_source::ScenarioUtils::GetUniqueIdForAircraftId(aircraft_id);
          return *this;
       }
-      Builder &ClearWaypoints() { intent_.ClearWaypoints(); return *this; }
       Builder &SetPlannedCruiseAltitude(Units::Length altitude) {
-         intent_.SetPlannedCruiseAltitude(altitude);
+         intent_ = *aaesim::open_source::DefaultAircraftIntent::Builder(intent_)
+                            .SetPlannedCruiseAltitude(altitude)
+                            .Build();
+         return *this;
+      }
+      Builder &SetPlannedCruiseMach(BoundedValue<double, 0, 1> mach) {
+         intent_ = *aaesim::open_source::DefaultAircraftIntent::Builder(intent_)
+                            .SetPlannedCruiseMach(mach)
+                            .Build();
          return *this;
       }
       Builder &InsertWaypointAtIndex(const Waypoint &waypoint, int index) {

--- a/include/imalgs/FIMAircraftIntent.h
+++ b/include/imalgs/FIMAircraftIntent.h
@@ -1,0 +1,92 @@
+// ****************************************************************************
+// NOTICE
+//
+// (c) 2026 The MITRE Corporation. All Rights Reserved.
+// ****************************************************************************
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "public/DefaultAircraftIntent.h"
+#include "public/AircraftIntentUtils.h"
+#include "public/ScenarioUtils.h"
+
+namespace interval_management::open_source {
+
+class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
+ public:
+   class Builder final {
+    public:
+      explicit Builder(const aaesim::open_source::DefaultAircraftIntent &intent) : intent_(intent) {}
+      explicit Builder(const std::shared_ptr<const aaesim::open_source::AircraftIntent> &intent)
+         : intent_(*aaesim::open_source::DefaultAircraftIntent::Builder(*intent).Build()) {}
+      explicit Builder(const std::shared_ptr<aaesim::open_source::AircraftIntent> &intent)
+         : intent_(*aaesim::open_source::DefaultAircraftIntent::Builder(*intent).Build()) {}
+      explicit Builder(const aaesim::open_source::AircraftIntent &intent)
+         : intent_(*aaesim::open_source::DefaultAircraftIntent::Builder(intent).Build()) {}
+
+      Builder &SetId(int id) { id_ = id; return *this; }
+      Builder &SetAircraftId(const std::string &aircraft_id) {
+         id_ = aaesim::open_source::ScenarioUtils::GetUniqueIdForAircraftId(aircraft_id);
+         return *this;
+      }
+      Builder &ClearWaypoints() { intent_.ClearWaypoints(); return *this; }
+      Builder &SetPlannedCruiseAltitude(Units::Length altitude) {
+         intent_.SetPlannedCruiseAltitude(altitude);
+         return *this;
+      }
+      Builder &InsertWaypointAtIndex(const Waypoint &waypoint, int index) {
+         intent_.InsertWaypointAtIndex(waypoint, index);
+         return *this;
+      }
+      Builder &InsertPairAtIndex(const std::string &name, Units::Length x, Units::Length y, int index) {
+         intent_.InsertPairAtIndex(name, x, y, index);
+         return *this;
+      }
+      Builder &UpdateWaypoint(const Waypoint &waypoint) { intent_.UpdateWaypoint(waypoint); return *this; }
+      FIMAircraftIntent Build() const { return FIMAircraftIntent(intent_, id_); }
+
+    private:
+      aaesim::open_source::DefaultAircraftIntent intent_{};
+      int id_{aaesim::open_source::ScenarioUtils::AIRCRAFT_ID_NOT_IN_MAP};
+   };
+
+   FIMAircraftIntent() = default;
+   int GetId() const { return id_; }
+
+   static FIMAircraftIntent CopyAndTrimAfterNamedWaypoint(const FIMAircraftIntent &intent,
+                                                           const std::string &waypoint_name) {
+      return Builder(aaesim::open_source::AircraftIntentUtils::CopyAndTrimAfterNamedWaypoint(intent, waypoint_name))
+            .SetId(intent.id_).Build();
+   }
+
+   const Waypoint &GetWaypoint(unsigned int i) const override { return intent_.GetWaypoint(i); }
+   const std::vector<Waypoint> &GetWaypoints() const override { return intent_.GetWaypoints(); }
+   const std::string &GetWaypointName(unsigned int i) const override { return intent_.GetWaypointName(i); }
+   Units::MetersLength GetPlannedCruiseAltitude() const override { return intent_.GetPlannedCruiseAltitude(); }
+   const RouteData &GetRouteData() const override { return intent_.GetRouteData(); }
+   int GetWaypointIndexByName(const std::string &name) const override { return intent_.GetWaypointIndexByName(name); }
+   std::pair<int, int> FindCommonWaypoint(const AircraftIntent &intent) const override {
+      return intent_.FindCommonWaypoint(intent);
+   }
+   unsigned int GetNumberOfWaypoints() const override { return intent_.GetNumberOfWaypoints(); }
+   const std::vector<Waypoint> &GetAscentWaypoints() const override { return intent_.GetAscentWaypoints(); }
+   const std::vector<Waypoint> &GetCruiseWaypoints() const override { return intent_.GetCruiseWaypoints(); }
+   const std::vector<Waypoint> &GetDescentWaypoints() const override { return intent_.GetDescentWaypoints(); }
+   double GetPlannedCruiseMach() const override { return intent_.GetPlannedCruiseMach(); }
+   bool ContainsWaypointName(const std::string &name) const override { return intent_.ContainsWaypointName(name); }
+
+   bool IsLoaded() const { return intent_.IsLoaded(); }
+   Units::MetersLength GetWaypointX(unsigned int index) const { return intent_.GetWaypointX(index); }
+   Units::MetersLength GetWaypointY(unsigned int index) const { return intent_.GetWaypointY(index); }
+
+ private:
+   FIMAircraftIntent(const aaesim::open_source::DefaultAircraftIntent &intent, int id) : intent_(intent), id_(id) {}
+
+   aaesim::open_source::DefaultAircraftIntent intent_{};
+   int id_{aaesim::open_source::ScenarioUtils::AIRCRAFT_ID_NOT_IN_MAP};
+};
+
+}  // namespace interval_management::open_source

--- a/include/imalgs/FIMAircraftIntent.h
+++ b/include/imalgs/FIMAircraftIntent.h
@@ -19,6 +19,7 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
  public:
    class Builder final {
     public:
+      Builder() = default;
       explicit Builder(const aaesim::open_source::DefaultAircraftIntent &intent) : intent_(intent) {}
       explicit Builder(const std::shared_ptr<const aaesim::open_source::AircraftIntent> &intent)
          : intent_(*aaesim::open_source::DefaultAircraftIntent::Builder(*intent).Build()) {}
@@ -46,6 +47,11 @@ class FIMAircraftIntent final : public aaesim::open_source::AircraftIntent {
          return *this;
       }
       Builder &UpdateWaypoint(const Waypoint &waypoint) { intent_.UpdateWaypoint(waypoint); return *this; }
+      Builder &LoadWaypoints(const std::vector<Waypoint> &ascent, const std::vector<Waypoint> &cruise,
+                             const std::vector<Waypoint> &descent) {
+         intent_.LoadWaypoints(ascent, cruise, descent);
+         return *this;
+      }
       FIMAircraftIntent Build() const { return FIMAircraftIntent(intent_, id_); }
 
     private:

--- a/include/imalgs/FIMAlgorithmAdapter.h
+++ b/include/imalgs/FIMAlgorithmAdapter.h
@@ -29,16 +29,19 @@
 
 namespace interval_management {
 namespace open_source {
-class FIMAlgorithmAdapter final : public aaesim::open_source::FlightDeckApplication {
+
+using namespace mitre::oss::simcore;
+
+class FIMAlgorithmAdapter final : public mitre::oss::simcore::FlightDeckApplication {
   public:
    FIMAlgorithmAdapter(std::shared_ptr<interval_management::open_source::IMAlgorithm> im_algorithm,
                        IMUtils::IMAlgorithmTypes algorithm_type);
    ~FIMAlgorithmAdapter() = default;
-   void Initialize(aaesim::open_source::FlightDeckApplicationInitializer &initializer_visitor) override;
-   aaesim::open_source::Guidance Update(const aaesim::open_source::SimulationTime &simtime,
-                                        const aaesim::open_source::Guidance &prevguidance,
-                                        const aaesim::open_source::DynamicsState &dynamicsstate,
-                                        const aaesim::open_source::AircraftState &owntruthstate) override;
+   void Initialize(mitre::oss::simcore::FlightDeckApplicationInitializer &initializer_visitor) override;
+   mitre::oss::simcore::Guidance Update(const mitre::oss::simcore::SimulationTime &simtime,
+                                        const mitre::oss::simcore::Guidance &prevguidance,
+                                        const mitre::oss::simcore::DynamicsState &dynamicsstate,
+                                        const mitre::oss::simcore::AircraftState &owntruthstate) override;
    bool IsActive() const override;
    std::shared_ptr<interval_management::open_source::IMAlgorithm> GetImAlgorithm() const;
    IMUtils::IMAlgorithmTypes GetImAlgorithmType() const;
@@ -49,13 +52,13 @@ class FIMAlgorithmAdapter final : public aaesim::open_source::FlightDeckApplicat
 
   private:
    inline static log4cplus::Logger m_logger{log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("FIMAlgorithmAdapter"))};
-   static void LogAircraftState(const aaesim::open_source::AircraftState &state);
-   void UpdateTargetHistory(const aaesim::open_source::SimulationTime &simtime);
+   static void LogAircraftState(const mitre::oss::simcore::AircraftState &state);
+   void UpdateTargetHistory(const mitre::oss::simcore::SimulationTime &simtime);
    interval_management::open_source::AircraftState ConvertAircraftState(
-         const aaesim::open_source::AircraftState &state) const;
+         const mitre::oss::simcore::AircraftState &state) const;
    std::shared_ptr<interval_management::open_source::IMAlgorithm> m_im_algorithm{};
    IMUtils::IMAlgorithmTypes m_im_algorithm_type{IMUtils::IMAlgorithmTypes::NONE};
-   std::shared_ptr<const aaesim::open_source::ASSAP> m_assap{};
+   std::shared_ptr<const mitre::oss::simcore::ASSAP> m_assap{};
    std::vector<interval_management::open_source::AircraftState> m_target_history{};
    std::shared_ptr<TangentPlaneSequence> m_position_converter{};
 };

--- a/include/imalgs/FIMAlgorithmDataWriter.h
+++ b/include/imalgs/FIMAlgorithmDataWriter.h
@@ -39,6 +39,9 @@
 
 namespace interval_management {
 namespace open_source {
+
+using namespace mitre::oss::simcore;
+
 class FIMAlgorithmDataWriter final : public OutputHandler {
   public:
    FIMAlgorithmDataWriter();
@@ -46,9 +49,9 @@ class FIMAlgorithmDataWriter final : public OutputHandler {
 
    virtual void Finish();
 
-   void Gather(const int iteration_number, const aaesim::open_source::SimulationTime &time,
+   void Gather(const int iteration_number, const mitre::oss::simcore::SimulationTime &time,
                const std::string &aircraft_id,
-               std::shared_ptr<const aaesim::open_source::FlightDeckApplication> application);
+               std::shared_ptr<const mitre::oss::simcore::FlightDeckApplication> application);
 
   private:
    struct SimData {

--- a/include/imalgs/FIMAlgorithmInitializer.h
+++ b/include/imalgs/FIMAlgorithmInitializer.h
@@ -31,7 +31,10 @@
 
 namespace interval_management {
 namespace open_source {
-class FIMAlgorithmInitializer final : public aaesim::open_source::FlightDeckApplicationInitializer {
+
+using namespace mitre::oss::simcore;
+
+class FIMAlgorithmInitializer final : public mitre::oss::simcore::FlightDeckApplicationInitializer {
   public:
    FIMAlgorithmInitializer() = default;
 
@@ -39,30 +42,30 @@ class FIMAlgorithmInitializer final : public aaesim::open_source::FlightDeckAppl
 
    class Builder {
      private:
-      aaesim::open_source::OwnshipPerformanceParameters m_performance_parameters;
-      aaesim::open_source::OwnshipFmsPredictionParameters m_prediction_parameters;
-      std::shared_ptr<const aaesim::open_source::ASSAP> m_surveillance_processor;
+      mitre::oss::simcore::OwnshipPerformanceParameters m_performance_parameters;
+      mitre::oss::simcore::OwnshipFmsPredictionParameters m_prediction_parameters;
+      std::shared_ptr<const mitre::oss::simcore::ASSAP> m_surveillance_processor;
 
      public:
       Builder()
          : m_performance_parameters(),
            m_prediction_parameters(),
-           m_surveillance_processor(std::make_shared<aaesim::open_source::PassThroughAssap>()) {};
+           m_surveillance_processor(std::make_shared<mitre::oss::simcore::PassThroughAssap>()) {};
       ~Builder() = default;
       const interval_management::open_source::FIMAlgorithmInitializer Build() const;
       Builder *AddOwnshipPerformanceParameters(
-            const aaesim::open_source::OwnshipPerformanceParameters &performance_parameters);
+            const mitre::oss::simcore::OwnshipPerformanceParameters &performance_parameters);
       Builder *AddOwnshipFmsPredictionParameters(
-            const aaesim::open_source::OwnshipFmsPredictionParameters &prediction_parameters);
-      Builder *AddSurveillanceProcessor(std::shared_ptr<const aaesim::open_source::ASSAP> processor);
+            const mitre::oss::simcore::OwnshipFmsPredictionParameters &prediction_parameters);
+      Builder *AddSurveillanceProcessor(std::shared_ptr<const mitre::oss::simcore::ASSAP> processor);
 
-      const aaesim::open_source::OwnshipPerformanceParameters &GetPerformanceParameters() const {
+      const mitre::oss::simcore::OwnshipPerformanceParameters &GetPerformanceParameters() const {
          return m_performance_parameters;
       };
-      const aaesim::open_source::OwnshipFmsPredictionParameters &GetFmsPredictionParameters() const {
+      const mitre::oss::simcore::OwnshipFmsPredictionParameters &GetFmsPredictionParameters() const {
          return m_prediction_parameters;
       };
-      std::shared_ptr<const aaesim::open_source::ASSAP> GetSurveillanceProcessor() const {
+      std::shared_ptr<const mitre::oss::simcore::ASSAP> GetSurveillanceProcessor() const {
          return m_surveillance_processor;
       };
    };

--- a/include/imalgs/FIMConfiguration.h
+++ b/include/imalgs/FIMConfiguration.h
@@ -27,6 +27,9 @@
 
 namespace interval_management {
 namespace open_source {
+
+using namespace mitre::oss::simcore;
+
 class FIMConfiguration final : public Loadable {
   public:
    FIMConfiguration() = default;

--- a/include/imalgs/FIMSpeedLimiter.h
+++ b/include/imalgs/FIMSpeedLimiter.h
@@ -30,7 +30,10 @@
 
 namespace interval_management {
 namespace open_source {
-class FIMSpeedLimiter final : public aaesim::open_source::SpeedCommandLimiter {
+
+using namespace mitre::oss::simcore;
+
+class FIMSpeedLimiter final : public mitre::oss::simcore::SpeedCommandLimiter {
   public:
    struct RfLegLimit {
       RfLegLimit(Units::Length distance_to_go, Units::Speed upper_ias_limit)
@@ -48,10 +51,10 @@ class FIMSpeedLimiter final : public aaesim::open_source::SpeedCommandLimiter {
    FIMSpeedLimiter();
 
    FIMSpeedLimiter(bool use_speed_quantization, bool use_speed_limiting,
-                   aaesim::open_source::bada_utils::FlapSpeeds flap_speeds,
-                   aaesim::open_source::bada_utils::FlightEnvelope flight_envelope,
-                   aaesim::open_source::bada_utils::Mass mass_data,
-                   const aaesim::open_source::bada_utils::Aerodynamics &aerodynamics,
+                   mitre::oss::simcore::bada_utils::FlapSpeeds flap_speeds,
+                   mitre::oss::simcore::bada_utils::FlightEnvelope flight_envelope,
+                   mitre::oss::simcore::bada_utils::Mass mass_data,
+                   const mitre::oss::simcore::bada_utils::Aerodynamics &aerodynamics,
                    const FIMSpeedQuantizer &speed_quantizer);
 
    ~FIMSpeedLimiter();
@@ -66,13 +69,13 @@ class FIMSpeedLimiter final : public aaesim::open_source::SpeedCommandLimiter {
                                   const Units::Speed current_ias_speed_command,
                                   const Units::Speed reference_velocity_mps, const Units::Length distance_to_go_to_abp,
                                   const Units::Length distance_to_go_to_ptp, const Units::Length ownship_altitude,
-                                  const aaesim::open_source::bada_utils::FlapConfiguration flap_configuration) override;
+                                  const mitre::oss::simcore::bada_utils::FlapConfiguration flap_configuration) override;
 
    BoundedValue<double, 0, 2> LimitMachCommand(
          const BoundedValue<double, 0, 2> &previous_reference_speed_command_mach,
          const BoundedValue<double, 0, 2> &current_mach_command, const BoundedValue<double, 0, 2> &nominal_mach,
          const Units::Mass &current_mass, const Units::Length &current_ownship_altitude,
-         const aaesim::open_source::WeatherPrediction &weather_prediction) override;
+         const mitre::oss::simcore::WeatherPrediction &weather_prediction) override;
 
    const interval_management::open_source::FIMSpeedQuantizer &GetSpeedQuantizer() const;
 
@@ -119,10 +122,10 @@ class FIMSpeedLimiter final : public aaesim::open_source::SpeedCommandLimiter {
    double m_low_speed_coef{0};
    double m_high_speed_coef{0};
    FIMSpeedQuantizer m_fim_quantizer;
-   aaesim::open_source::bada_utils::FlapSpeeds m_flap_speeds{};
-   aaesim::open_source::bada_utils::FlightEnvelope m_aircraft_flight_envelope{};
-   aaesim::open_source::bada_utils::Mass m_mass_data{};
-   aaesim::open_source::bada_utils::Aerodynamics m_aerodynamics{};
+   mitre::oss::simcore::bada_utils::FlapSpeeds m_flap_speeds{};
+   mitre::oss::simcore::bada_utils::FlightEnvelope m_aircraft_flight_envelope{};
+   mitre::oss::simcore::bada_utils::Mass m_mass_data{};
+   mitre::oss::simcore::bada_utils::Aerodynamics m_aerodynamics{};
 };
 
 inline const interval_management::open_source::FIMSpeedQuantizer &FIMSpeedLimiter::GetSpeedQuantizer() const {

--- a/include/imalgs/IMAchieve.h
+++ b/include/imalgs/IMAchieve.h
@@ -31,6 +31,9 @@
 namespace interval_management {
 namespace open_source {
 
+using namespace mitre::oss::simcore;
+
+
 class IMAchieve : public IMAlgorithm {
   public:
    static const Units::Angle TOLERANCE_ANGLE;
@@ -43,15 +46,15 @@ class IMAchieve : public IMAlgorithm {
 
    void IterationReset() override;
 
-   aaesim::open_source::Guidance Update(
-         const aaesim::open_source::Guidance &prevguidance, const aaesim::open_source::DynamicsState &dynamicsstate,
+   mitre::oss::simcore::Guidance Update(
+         const mitre::oss::simcore::Guidance &prevguidance, const mitre::oss::simcore::DynamicsState &dynamicsstate,
          const interval_management::open_source::AircraftState &owntruthstate,
          const interval_management::open_source::AircraftState &targettruthstate,
          const std::vector<interval_management::open_source::AircraftState> &targethistory) override;
 
    void Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                    const AircraftIntent &ownship_aircraft_intent,
-                   aaesim::open_source::WeatherPrediction &weather_prediction) override;
+                   mitre::oss::simcore::WeatherPrediction &weather_prediction) override;
 
    void DumpParameters(const std::string &parameters_to_print) override;
 
@@ -69,7 +72,7 @@ class IMAchieve : public IMAlgorithm {
    void Copy(const IMAchieve &obj);
 
    virtual void CalculateIas(const Units::Length current_ownship_altitude,
-                             const aaesim::open_source::DynamicsState &three_dof_dynamics_state);
+                             const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state);
 
    virtual void CalculateMach(const Units::Time reference_ttg, const Units::Length current_ownship_altitude);
 
@@ -78,16 +81,16 @@ class IMAchieve : public IMAlgorithm {
    virtual void RecordInternalObserverMetrics(
          const interval_management::open_source::AircraftState &current_ownship_state,
          const interval_management::open_source::AircraftState &current_target_state,
-         const aaesim::open_source::DynamicsState &dynamics_state, const Units::Speed unmodified_ias,
+         const mitre::oss::simcore::DynamicsState &dynamics_state, const Units::Speed unmodified_ias,
          const Units::Speed tas_command, const Units::Speed reference_velocity, const Units::Length reference_distance,
-         const aaesim::open_source::Guidance &guidance);
+         const mitre::oss::simcore::Guidance &guidance);
 
    const bool WithinErrorThreshold(const Units::Length distance_to_go, const Units::Time ownship_ttg,
                                    const Units::Time reference_ttg);
 
    Units::Time GetErrorThreshold(Units::Length distance_to_go);
 
-   static const std::shared_ptr<aaesim::open_source::PredictedWindEvaluator> m_predicted_wind_evaluator;
+   static const std::shared_ptr<mitre::oss::simcore::PredictedWindEvaluator> m_predicted_wind_evaluator;
 
    bool m_transitioned_to_maintain{false};
    bool m_within_error_threshold{false};
@@ -113,7 +116,7 @@ inline const bool IMAchieve::IsWithinErrorThreshold() const { return m_within_er
 inline const bool IMAchieve::IsOwnshipBelowTransitionAltitude(Units::Length current_ownship_altitude) { return false; }
 
 inline void IMAchieve::CalculateIas(const Units::Length current_ownship_altitude,
-                                    const aaesim::open_source::DynamicsState &three_dof_dynamics_state) {
+                                    const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state) {
    // Do nothing.
 }
 
@@ -124,9 +127,9 @@ inline void IMAchieve::CalculateMach(const Units::Time reference_ttg, const Unit
 inline void IMAchieve::RecordInternalObserverMetrics(
       const interval_management::open_source::AircraftState &current_ownship_state,
       const interval_management::open_source::AircraftState &current_target_state,
-      const aaesim::open_source::DynamicsState &dynamics_state, const Units::Speed unmodified_ias,
+      const mitre::oss::simcore::DynamicsState &dynamics_state, const Units::Speed unmodified_ias,
       const Units::Speed tas_command, const Units::Speed reference_velocity, const Units::Length reference_distance,
-      const aaesim::open_source::Guidance &guidance) {
+      const mitre::oss::simcore::Guidance &guidance) {
    // Do Nothing
 }
 

--- a/include/imalgs/IMAlgorithm.h
+++ b/include/imalgs/IMAlgorithm.h
@@ -44,6 +44,9 @@
 namespace interval_management {
 namespace open_source {
 
+using namespace mitre::oss::simcore;
+
+
 class IMAlgorithm {
   public:
    static const std::string RESET_MSG;
@@ -57,10 +60,10 @@ class IMAlgorithm {
       double transition_mach{0};
       Units::Length transition_altitude{};
       Units::Length expected_cruise_altitude{};
-      aaesim::open_source::bada_utils::FlapSpeeds flap_speeds{};
-      aaesim::open_source::bada_utils::FlightEnvelope flight_envelope{};
-      aaesim::open_source::bada_utils::Mass mass_data{};
-      aaesim::open_source::bada_utils::Aerodynamics aerodynamics{};
+      mitre::oss::simcore::bada_utils::FlapSpeeds flap_speeds{};
+      mitre::oss::simcore::bada_utils::FlightEnvelope flight_envelope{};
+      mitre::oss::simcore::bada_utils::Mass mass_data{};
+      mitre::oss::simcore::bada_utils::Aerodynamics aerodynamics{};
    };
 
    IMAlgorithm();
@@ -73,15 +76,15 @@ class IMAlgorithm {
 
    virtual void Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                            const AircraftIntent &ownship_aircraft_intent,
-                           aaesim::open_source::WeatherPrediction &weather_prediction);
+                           mitre::oss::simcore::WeatherPrediction &weather_prediction);
 
    // Called during initialization whenever the clearance type is not CUSTOM.
    virtual void ResetDefaults();
 
    virtual void IterationReset();
 
-   virtual aaesim::open_source::Guidance Update(
-         const aaesim::open_source::Guidance &prevguidance, const aaesim::open_source::DynamicsState &dynamicsstate,
+   virtual mitre::oss::simcore::Guidance Update(
+         const mitre::oss::simcore::Guidance &prevguidance, const mitre::oss::simcore::DynamicsState &dynamicsstate,
          const interval_management::open_source::AircraftState &owntruthstate,
          const interval_management::open_source::AircraftState &targettruthstate,
          const std::vector<interval_management::open_source::AircraftState> &targethistory);
@@ -95,7 +98,7 @@ class IMAlgorithm {
    void UpdatePositionMetrics(const interval_management::open_source::AircraftState &ownship_aircraft_state,
                               const interval_management::open_source::AircraftState &target_aircraft_state);
 
-   void SetPilotDelay(aaesim::open_source::StatisticalPilotDelay &pilot_delay);
+   void SetPilotDelay(mitre::oss::simcore::StatisticalPilotDelay &pilot_delay);
 
    void DisablePilotDelayModel();
 
@@ -220,8 +223,8 @@ class IMAlgorithm {
    FIMAircraftIntent m_target_aircraft_intent;
    FlightStage m_stage_of_im_operation;
    IMClearance m_im_clearance;
-   aaesim::open_source::StatisticalPilotDelay m_pilot_delay;
-   aaesim::open_source::WeatherPrediction m_weather_prediction;
+   mitre::oss::simcore::StatisticalPilotDelay m_pilot_delay;
+   mitre::oss::simcore::WeatherPrediction m_weather_prediction;
    interval_management::open_source::FIMSpeedLimiter m_speed_limiter;
 
    Units::Speed m_previous_reference_im_speed_command_tas;
@@ -283,7 +286,7 @@ class IMAlgorithm {
 
   private:
    void IterClearIMAlg();
-   void SetWeatherPrediction(const aaesim::open_source::WeatherPrediction &weather_prediction);
+   void SetWeatherPrediction(const mitre::oss::simcore::WeatherPrediction &weather_prediction);
 
    static log4cplus::Logger m_logger;
 };
@@ -359,7 +362,7 @@ inline const bool IMAlgorithm::IsLoaded() const { return m_loaded; }
 
 inline bool IMAlgorithm::IsBlendWind() const { return m_loaded_use_wind_blending; }
 
-inline void IMAlgorithm::SetWeatherPrediction(const aaesim::open_source::WeatherPrediction &weather_prediction) {
+inline void IMAlgorithm::SetWeatherPrediction(const mitre::oss::simcore::WeatherPrediction &weather_prediction) {
    m_weather_prediction = weather_prediction;
 }
 

--- a/include/imalgs/IMAlgorithm.h
+++ b/include/imalgs/IMAlgorithm.h
@@ -33,6 +33,7 @@
 #include "imalgs/FIMConfiguration.h"
 #include "imalgs/FIMSpeedLimiter.h"
 #include "imalgs/IMClearance.h"
+#include "imalgs/FIMAircraftIntent.h"
 #include "public/AircraftIntent.h"
 #include "public/BadaUtils.h"
 #include "public/Guidance.h"
@@ -216,7 +217,7 @@ class IMAlgorithm {
 
    void SetActiveFilter(unsigned long flag);
 
-   AircraftIntent m_target_aircraft_intent;
+   FIMAircraftIntent m_target_aircraft_intent;
    FlightStage m_stage_of_im_operation;
    IMClearance m_im_clearance;
    aaesim::open_source::StatisticalPilotDelay m_pilot_delay;

--- a/include/imalgs/IMClearance.h
+++ b/include/imalgs/IMClearance.h
@@ -33,6 +33,9 @@
 
 namespace interval_management {
 namespace open_source {
+
+using namespace mitre::oss::simcore;
+
 class IMClearance final {
   public:
    enum ClearanceType { NONE = -1, CUSTOM = 0, CAPTURE, MAINTAIN, ACHIEVE, FAS };

--- a/include/imalgs/IMClearance.h
+++ b/include/imalgs/IMClearance.h
@@ -28,6 +28,7 @@
 #include <string>
 
 #include "imalgs/IMUtils.h"
+#include "imalgs/FIMAircraftIntent.h"
 #include "public/AircraftIntent.h"
 
 namespace interval_management {
@@ -46,8 +47,8 @@ class IMClearance final {
      private:
       ClearanceType m_builder_clearance_type;
       SpacingGoalType m_builder_assigned_spacing_goal_type;
-      AircraftIntent m_builder_target_aircraft_intent;
-      AircraftIntent m_builder_ownship_intent;
+      FIMAircraftIntent m_builder_target_aircraft_intent;
+      FIMAircraftIntent m_builder_ownship_intent;
       Units::RadiansAngle m_builder_final_approach_spacing_merge_angle_mean;
       Units::RadiansAngle m_builder_final_approach_spacing_merge_angle_std;
       std::string m_builder_achieve_by_point;
@@ -63,7 +64,7 @@ class IMClearance final {
               const SpacingGoalType &assigned_spacing_goal_type, const double assigned_spacing_goal)
          : m_builder_clearance_type(clearance_type),
            m_builder_assigned_spacing_goal_type(assigned_spacing_goal_type),
-           m_builder_target_aircraft_intent(target_intent),
+           m_builder_target_aircraft_intent(FIMAircraftIntent::Builder(target_intent).SetId(target_id).Build()),
            m_builder_ownship_intent(),
            m_builder_final_approach_spacing_merge_angle_mean(0),
            m_builder_final_approach_spacing_merge_angle_std(0),
@@ -76,7 +77,7 @@ class IMClearance final {
       ~Builder() = default;
       const IMClearance Build() const { return IMClearance(this); }
       Builder *OwnshipIntent(const AircraftIntent &ownship_intent) {
-         m_builder_ownship_intent = ownship_intent;
+         m_builder_ownship_intent = FIMAircraftIntent::Builder(ownship_intent).Build();
          return this;
       };
       Builder *TrafficReferencePoint(const std::string &traffic_reference_point) {
@@ -93,8 +94,10 @@ class IMClearance final {
 
       ClearanceType GetClearanceType() const { return m_builder_clearance_type; };
       SpacingGoalType GetSpacingGoalType() const { return m_builder_assigned_spacing_goal_type; };
-      const AircraftIntent &GetTargetAircraftIntent() const { return m_builder_target_aircraft_intent; };
-      const AircraftIntent &GetOwnshipAircraftIntent() const { return m_builder_ownship_intent; };
+      const FIMAircraftIntent &GetTargetAircraftIntent() const { return m_builder_target_aircraft_intent; };
+      const FIMAircraftIntent &GetOwnshipAircraftIntent() const {
+         return m_builder_ownship_intent;
+      };
       Units::RadiansAngle GetMergeAngleMean() const { return m_builder_final_approach_spacing_merge_angle_mean; };
       Units::RadiansAngle GetMergeAngleStd() const { return m_builder_final_approach_spacing_merge_angle_std; };
       const std::string &GetAchieveByPoint() const { return m_builder_achieve_by_point; };
@@ -139,7 +142,7 @@ class IMClearance final {
 
    const AircraftIntent &GetTargetAircraftIntent() const { return m_target_aircraft_intent; }
 
-   const std::optional<AircraftIntent> GetOwnshipIntent() const {
+   const std::optional<FIMAircraftIntent> GetOwnshipIntent() const {
       if (m_ownship_intent.IsLoaded()) return std::optional{m_ownship_intent};
       return {};
    }
@@ -164,8 +167,8 @@ class IMClearance final {
 
    ClearanceType m_clearance_type{CUSTOM};
    SpacingGoalType m_assigned_spacing_goal_type{TIME};
-   AircraftIntent m_target_aircraft_intent{};
-   AircraftIntent m_ownship_intent{};
+   FIMAircraftIntent m_target_aircraft_intent{};
+   FIMAircraftIntent m_ownship_intent{};
    Units::RadiansAngle m_final_approach_spacing_merge_angle_mean{0};
    Units::RadiansAngle m_final_approach_spacing_merge_angle_std{0};
    std::string m_achieve_by_point{};

--- a/include/imalgs/IMDistBasedAchieve.h
+++ b/include/imalgs/IMDistBasedAchieve.h
@@ -29,6 +29,9 @@
 
 namespace interval_management {
 namespace open_source {
+
+using namespace mitre::oss::simcore;
+
 class IMDistBasedAchieve final : public IMKinematicAchieve {
   public:
    static const Units::Length DEFAULT_DISTANCE_BASED_ASSIGNED_SPACING_GOAL;
@@ -43,16 +46,16 @@ class IMDistBasedAchieve final : public IMKinematicAchieve {
 
    void Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                    const AircraftIntent &ownship_aircraft_intent,
-                   aaesim::open_source::WeatherPrediction &weather_prediction,
+                   mitre::oss::simcore::WeatherPrediction &weather_prediction,
                    std::shared_ptr<TangentPlaneSequence> &position_converter) override;
 
    virtual void Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                            const AircraftIntent &ownship_aircraft_intent,
-                           aaesim::open_source::WeatherPrediction &weather_prediction) override;
+                           mitre::oss::simcore::WeatherPrediction &weather_prediction) override;
 
-   virtual aaesim::open_source::Guidance Update(
-         const aaesim::open_source::Guidance &previous_im_guidance,
-         const aaesim::open_source::DynamicsState &three_dof_dynamics_state,
+   virtual mitre::oss::simcore::Guidance Update(
+         const mitre::oss::simcore::Guidance &previous_im_guidance,
+         const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state,
          const interval_management::open_source::AircraftState &current_ownship_state,
          const interval_management::open_source::AircraftState &current_target_state,
          const std::vector<interval_management::open_source::AircraftState> &target_adsb_history) override;
@@ -89,17 +92,17 @@ class IMDistBasedAchieve final : public IMKinematicAchieve {
 
   protected:
    virtual void CalculateIas(const Units::Length current_ownship_altitude,
-                             const aaesim::open_source::DynamicsState &three_dof_dynamics_state) override;
+                             const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state) override;
 
    virtual void CalculateMach(const Units::Time reference_ttg, const Units::Length current_ownship_altitude,
                               const Units::Mass current_mass);
 
    void Copy(const IMDistBasedAchieve &obj);
 
-   void RecordData(aaesim::open_source::Guidance &im_guidance,
+   void RecordData(mitre::oss::simcore::Guidance &im_guidance,
                    const interval_management::open_source::AircraftState &current_ownship_state,
                    const interval_management::open_source::AircraftState &current_target_state,
-                   const aaesim::open_source::DynamicsState &three_dof_dynamics_state,
+                   const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state,
                    Units::Speed unmodified_im_speed_command_ias, Units::Speed im_speed_command_tas,
                    Units::Speed ownship_reference_true_airspeed, Units::Length ownship_reference_dtg_to_ptp,
                    Units::Time target_reference_ttg_to_trp);
@@ -120,8 +123,8 @@ class IMDistBasedAchieve final : public IMKinematicAchieve {
    Units::Length m_predicted_spacing_interval;
    Units::Length m_measured_spacing_interval;
    Units::Length m_assigned_spacing_goal;
-   aaesim::open_source::AlongPathDistanceCalculator m_distance_calculator_target_on_ownship_hpath;
-   aaesim::open_source::PositionCalculator m_position_calculator_target_on_ownship_hpath;
+   mitre::oss::simcore::AlongPathDistanceCalculator m_distance_calculator_target_on_ownship_hpath;
+   mitre::oss::simcore::PositionCalculator m_position_calculator_target_on_ownship_hpath;
 
    static log4cplus::Logger m_logger;
 };

--- a/include/imalgs/IMKinematicAchieve.h
+++ b/include/imalgs/IMKinematicAchieve.h
@@ -27,6 +27,7 @@
 #include "imalgs/IMAchieve.h"
 #include "imalgs/IMKinematicTimeBasedMaintain.h"
 #include "imalgs/InternalObserver.h"
+#include "imalgs/FIMAircraftIntent.h"
 #include "public/BlendWindsVerticallyByAltitude.h"
 #include "public/KinematicTrajectoryPredictor.h"
 #include "public/WindBlendingAlgorithm.h"
@@ -139,7 +140,7 @@ class IMKinematicAchieve : public IMAchieve, public Loadable {
    Waypoint m_traffic_reference_point;
    interval_management::open_source::AchievePointCalcs m_target_kinematic_traffic_reference_point_calcs;
 
-   AircraftIntent m_ownship_aircraft_intent;
+   FIMAircraftIntent m_ownship_aircraft_intent;
 
    aaesim::open_source::AlongPathDistanceCalculator m_ownship_distance_calculator;
    aaesim::open_source::AlongPathDistanceCalculator m_target_distance_calculator;

--- a/include/imalgs/IMKinematicAchieve.h
+++ b/include/imalgs/IMKinematicAchieve.h
@@ -35,6 +35,9 @@
 namespace interval_management {
 namespace open_source {
 
+using namespace mitre::oss::simcore;
+
+
 class IMKinematicAchieve : public IMAchieve, public Loadable {
   public:
    enum RFLegPhase { NON_RF_LEG, ON_RF_LEG, PRE_RF_LEG };
@@ -51,15 +54,15 @@ class IMKinematicAchieve : public IMAchieve, public Loadable {
 
    void Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                    const AircraftIntent &ownship_aircraft_intent,
-                   aaesim::open_source::WeatherPrediction &weather_prediction) override;
+                   mitre::oss::simcore::WeatherPrediction &weather_prediction) override;
 
    virtual void Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                            const AircraftIntent &ownship_aircraft_intent,
-                           aaesim::open_source::WeatherPrediction &weather_prediction,
+                           mitre::oss::simcore::WeatherPrediction &weather_prediction,
                            std::shared_ptr<TangentPlaneSequence> &position_converter) = 0;
 
-   aaesim::open_source::Guidance Update(
-         const aaesim::open_source::Guidance &prevguidance, const aaesim::open_source::DynamicsState &dynamicsstate,
+   mitre::oss::simcore::Guidance Update(
+         const mitre::oss::simcore::Guidance &prevguidance, const mitre::oss::simcore::DynamicsState &dynamicsstate,
          const interval_management::open_source::AircraftState &owntruthstate,
          const interval_management::open_source::AircraftState &targettruthstate,
          const std::vector<interval_management::open_source::AircraftState> &targethistory) override;
@@ -101,9 +104,9 @@ class IMKinematicAchieve : public IMAchieve, public Loadable {
     */
    bool IsNewTrajectoryPredictionAvailable() const;
 
-   const aaesim::open_source::KinematicTrajectoryPredictor &GetOwnshipKinematicPredictor() const;
+   const mitre::oss::simcore::KinematicTrajectoryPredictor &GetOwnshipKinematicPredictor() const;
 
-   const aaesim::open_source::KinematicTrajectoryPredictor &GetTargetKinematicPredictor() const;
+   const mitre::oss::simcore::KinematicTrajectoryPredictor &GetTargetKinematicPredictor() const;
 
    bool load(DecodedStream *input) override;
 
@@ -122,7 +125,7 @@ class IMKinematicAchieve : public IMAchieve, public Loadable {
    void CalculateRFLegPhase(const std::vector<PrecalcWaypoint> &waypoints,
                             const Units::Acceleration deceleration_rate_flight_path_angle,
                             const VerticalPath &vertical_path,
-                            const std::vector<aaesim::open_source::HorizontalPath> &horizontal_trajectory);
+                            const std::vector<mitre::oss::simcore::HorizontalPath> &horizontal_trajectory);
 
    void ComputeFASTrajectories(const interval_management::open_source::AircraftState &owntruthstate,
                                const interval_management::open_source::AircraftState &targettruthstate);
@@ -133,8 +136,8 @@ class IMKinematicAchieve : public IMAchieve, public Loadable {
    void SetTrafficReferencePointConstraints(const interval_management::open_source::AircraftState &owntruthstate,
                                             const interval_management::open_source::AircraftState &targetsyncstate);
 
-   aaesim::open_source::KinematicTrajectoryPredictor m_ownship_kinematic_trajectory_predictor;
-   aaesim::open_source::KinematicTrajectoryPredictor m_target_kinematic_trajectory_predictor;
+   mitre::oss::simcore::KinematicTrajectoryPredictor m_ownship_kinematic_trajectory_predictor;
+   mitre::oss::simcore::KinematicTrajectoryPredictor m_target_kinematic_trajectory_predictor;
 
    interval_management::open_source::AchievePointCalcs m_ownship_kinematic_achieve_by_calcs;
    Waypoint m_traffic_reference_point;
@@ -142,9 +145,9 @@ class IMKinematicAchieve : public IMAchieve, public Loadable {
 
    FIMAircraftIntent m_ownship_aircraft_intent;
 
-   aaesim::open_source::AlongPathDistanceCalculator m_ownship_distance_calculator;
-   aaesim::open_source::AlongPathDistanceCalculator m_target_distance_calculator;
-   aaesim::open_source::AlongPathDistanceCalculator m_im_ownship_distance_calculator;
+   mitre::oss::simcore::AlongPathDistanceCalculator m_ownship_distance_calculator;
+   mitre::oss::simcore::AlongPathDistanceCalculator m_target_distance_calculator;
+   mitre::oss::simcore::AlongPathDistanceCalculator m_im_ownship_distance_calculator;
 
    std::list<Units::Angle> m_ownship_track_angle_history;
    std::list<Units::Angle> m_target_track_angle_history;
@@ -161,8 +164,8 @@ class IMKinematicAchieve : public IMAchieve, public Loadable {
    bool m_is_target_aligned;
    bool m_new_trajectory_prediction_available;
 
-   std::shared_ptr<aaesim::open_source::WindBlendingAlgorithm> m_wind_blender{
-         std::make_shared<aaesim::open_source::BlendWindsVerticallyByAltitude>()};
+   std::shared_ptr<mitre::oss::simcore::WindBlendingAlgorithm> m_wind_blender{
+         std::make_shared<mitre::oss::simcore::BlendWindsVerticallyByAltitude>()};
 
    static const Units::FeetLength TARGET_ALTITUDE_TOLERANCE;
 
@@ -222,12 +225,12 @@ inline std::shared_ptr<VerticalPredictor> IMKinematicAchieve::GetTargetVerticalP
    return nullptr;
 }
 
-inline const aaesim::open_source::KinematicTrajectoryPredictor &IMKinematicAchieve::GetOwnshipKinematicPredictor()
+inline const mitre::oss::simcore::KinematicTrajectoryPredictor &IMKinematicAchieve::GetOwnshipKinematicPredictor()
       const {
    return m_ownship_kinematic_trajectory_predictor;
 }
 
-inline const aaesim::open_source::KinematicTrajectoryPredictor &IMKinematicAchieve::GetTargetKinematicPredictor()
+inline const mitre::oss::simcore::KinematicTrajectoryPredictor &IMKinematicAchieve::GetTargetKinematicPredictor()
       const {
    return m_target_kinematic_trajectory_predictor;
 }

--- a/include/imalgs/IMKinematicDistBasedMaintain.h
+++ b/include/imalgs/IMKinematicDistBasedMaintain.h
@@ -29,6 +29,9 @@
 
 namespace interval_management {
 namespace open_source {
+
+using namespace mitre::oss::simcore;
+
 class IMKinematicDistBasedMaintain final : public IMMaintain {
   public:
    IMKinematicDistBasedMaintain();
@@ -38,19 +41,19 @@ class IMKinematicDistBasedMaintain final : public IMMaintain {
    virtual void IterationReset();
 
    // Does NOT inherit from IMAlgorithm::Update()
-   aaesim::open_source::Guidance Update(
-         const aaesim::open_source::DynamicsState &dynamics_state,
+   mitre::oss::simcore::Guidance Update(
+         const mitre::oss::simcore::DynamicsState &dynamics_state,
          const interval_management::open_source::AircraftState &ownship_aircraft_state,
          const interval_management::open_source::AircraftState
                &target_state_projected_on_ownships_path_at_adjusted_distance,
          const Units::Length target_dtg_along_ownships_path_at_adjusted_distance,
          const Units::Length target_dtg_along_ownships_path,
-         const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-         const aaesim::open_source::Guidance &guidance_in,
+         const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+         const mitre::oss::simcore::Guidance &guidance_in,
          const std::vector<interval_management::open_source::AircraftState> &target_aircraft_state_history,
          const interval_management::open_source::AchievePointCalcs &ownship_achieve_point_calcs,
          const interval_management::open_source::AchievePointCalcs &traffic_reference_point_calcs,
-         aaesim::open_source::StatisticalPilotDelay &pilot_delay);
+         mitre::oss::simcore::StatisticalPilotDelay &pilot_delay);
 
    virtual const double GetMsi() const;
 
@@ -61,27 +64,27 @@ class IMKinematicDistBasedMaintain final : public IMMaintain {
   private:
    void CalculateIas(const Units::Length current_ownship_altitude,
                      const Units::Length target_kinematic_dtg_to_end_of_route,
-                     const aaesim::open_source::DynamicsState &dynamics_state,
-                     const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-                     aaesim::open_source::StatisticalPilotDelay &pilot_delay);
+                     const mitre::oss::simcore::DynamicsState &dynamics_state,
+                     const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+                     mitre::oss::simcore::StatisticalPilotDelay &pilot_delay);
 
    void CalculateMach(const Units::Length current_ownship_altitude,
                       const Units::Length target_kinematic_dtg_to_end_of_route,
                       const Units::Speed true_airspeed_command,
-                      const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-                      aaesim::open_source::StatisticalPilotDelay &pilot_delay, const Units::Mass current_mass);
+                      const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+                      mitre::oss::simcore::StatisticalPilotDelay &pilot_delay, const Units::Mass current_mass);
 
    void RecordInternalObserverData(
          const interval_management::open_source::AircraftState &ownship_aircraft_state,
          const interval_management::open_source::AircraftState &target_aircraft_state,
-         const aaesim::open_source::DynamicsState &dynamics_state, const Units::Speed true_airspeed_command,
+         const mitre::oss::simcore::DynamicsState &dynamics_state, const Units::Speed true_airspeed_command,
          const Units::Length target_true_dtg, const Units::Length ownship_true_dtg,
          const std::vector<interval_management::open_source::AircraftState> &target_aircraft_state_history,
-         const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor);
+         const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor);
 
    const bool IsOwnshipBelowTransitionAltitude(
          Units::Length current_ownship_altitude,
-         const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor);
+         const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor);
 
    Units::Length m_measured_spacing_interval;
 
@@ -90,7 +93,7 @@ class IMKinematicDistBasedMaintain final : public IMMaintain {
 
 inline const bool IMKinematicDistBasedMaintain::IsOwnshipBelowTransitionAltitude(
       Units::Length current_ownship_altitude,
-      const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor) {
+      const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor) {
    return current_ownship_altitude <
           ownship_kinematic_trajectory_predictor.GetKinematicDescent4dPredictor()->GetTransitionAltitude();
 }

--- a/include/imalgs/IMKinematicTimeBasedMaintain.h
+++ b/include/imalgs/IMKinematicTimeBasedMaintain.h
@@ -31,6 +31,9 @@
 
 namespace interval_management {
 namespace open_source {
+
+using namespace mitre::oss::simcore;
+
 class IMKinematicTimeBasedMaintain final : public IMMaintain {
   public:
    IMKinematicTimeBasedMaintain();
@@ -39,16 +42,16 @@ class IMKinematicTimeBasedMaintain final : public IMMaintain {
 
    virtual void IterationReset();
 
-   aaesim::open_source::Guidance Update(
-         const aaesim::open_source::DynamicsState &dynamics_state,
+   mitre::oss::simcore::Guidance Update(
+         const mitre::oss::simcore::DynamicsState &dynamics_state,
          const interval_management::open_source::AircraftState &ownship_aircraft_state,
          const interval_management::open_source::AircraftState &target_aircraft_state_projected_asg_adjusted,
-         const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-         const aaesim::open_source::Guidance &guidance_in,
+         const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+         const mitre::oss::simcore::Guidance &guidance_in,
          const std::vector<interval_management::open_source::AircraftState> &target_aircraft_state_history,
          const interval_management::open_source::AchievePointCalcs &ownship_achieve_point_calcs,
          const interval_management::open_source::AchievePointCalcs &traffic_reference_point_calcs,
-         aaesim::open_source::StatisticalPilotDelay &pilot_delay_model,
+         mitre::oss::simcore::StatisticalPilotDelay &pilot_delay_model,
          const Units::Length &target_kinematic_dtg_to_end_of_route);
 
    virtual const double GetMsi() const;
@@ -66,24 +69,24 @@ class IMKinematicTimeBasedMaintain final : public IMMaintain {
          bool target_crossing_time_valid) const;
 
    void CalculateIas(const Units::Length current_ownship_altitude,
-                     const aaesim::open_source::DynamicsState &dynamics_state,
-                     const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-                     aaesim::open_source::StatisticalPilotDelay &pilot_delay);
+                     const mitre::oss::simcore::DynamicsState &dynamics_state,
+                     const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+                     mitre::oss::simcore::StatisticalPilotDelay &pilot_delay);
 
    void CalculateMach(const Units::Length current_ownship_altitude, const Units::Speed true_airspeed_command,
-                      const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
-                      aaesim::open_source::StatisticalPilotDelay &pilot_delay, const Units::Mass current_mass);
+                      const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor,
+                      mitre::oss::simcore::StatisticalPilotDelay &pilot_delay, const Units::Mass current_mass);
 
    const bool IsOwnshipBelowTransitionAltitude(
          Units::Length current_ownship_altitude,
-         const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor);
+         const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor);
 
    Units::Time m_measured_spacing_interval;
 };
 
 inline const bool IMKinematicTimeBasedMaintain::IsOwnshipBelowTransitionAltitude(
       Units::Length current_ownship_altitude,
-      const aaesim::open_source::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor) {
+      const mitre::oss::simcore::KinematicTrajectoryPredictor &ownship_kinematic_trajectory_predictor) {
    return current_ownship_altitude <
           ownship_kinematic_trajectory_predictor.GetKinematicDescent4dPredictor()->GetTransitionAltitude();
 }

--- a/include/imalgs/IMMaintain.h
+++ b/include/imalgs/IMMaintain.h
@@ -31,6 +31,9 @@
 namespace interval_management {
 namespace open_source {
 
+using namespace mitre::oss::simcore;
+
+
 class IMMaintain : public IMAlgorithm {
   public:
    static const Units::HertzFrequency MAINTAIN_CONTROL_GAIN_DEFAULT;
@@ -49,8 +52,8 @@ class IMMaintain : public IMAlgorithm {
 
    virtual void Prepare(Units::Speed previous_im_speed_command, Units::Speed previous_ias_command,
                         interval_management::open_source::FIMSpeedLimiter speed_limiter, double previous_mach_command,
-                        const aaesim::open_source::EuclideanTrajectoryPredictor &ownship_trajectory_predictor,
-                        const aaesim::open_source::AlongPathDistanceCalculator &im_distance_calculator,
+                        const mitre::oss::simcore::EuclideanTrajectoryPredictor &ownship_trajectory_predictor,
+                        const mitre::oss::simcore::AlongPathDistanceCalculator &im_distance_calculator,
                         const std::vector<interval_management::open_source::AircraftState> &target_adsb_track_history,
                         const IMClearance &im_clearance,
                         const std::vector<interval_management::open_source::FIMSpeedLimiter::RfLegLimit> &rf_limits);
@@ -68,8 +71,8 @@ class IMMaintain : public IMAlgorithm {
   protected:
    void Copy(const IMMaintain &obj);
 
-   aaesim::open_source::AlongPathDistanceCalculator m_ownship_decrementing_distance_calculator;
-   aaesim::open_source::AlongPathDistanceCalculator m_ownship_distance_calculator;
+   mitre::oss::simcore::AlongPathDistanceCalculator m_ownship_decrementing_distance_calculator;
+   mitre::oss::simcore::AlongPathDistanceCalculator m_ownship_distance_calculator;
 
   private:
    static log4cplus::Logger m_logger;

--- a/include/imalgs/IMTimeBasedAchieve.h
+++ b/include/imalgs/IMTimeBasedAchieve.h
@@ -243,7 +243,7 @@ inline void IMTimeBasedAchieve::DoAlgorithmLogging(
       j["im_speed_command_ias_mps"] = Units::MetersPerSecondSpeed(m_im_speed_command_ias).value();
       j["ownship_ttg_to_abp_sec"] = Units::SecondsTime(m_ownship_ttg_to_abp).value();
       j["target_ttg_to_trp_sec"] = Units::SecondsTime(m_target_ttg_to_trp).value();
-      j["ownship_selected_speed_type"] = guidance_out.GetSelectedSpeed().GetSpeedType();
+      j["ownship_selected_speed_type"] = guidance_out.GetSelectedSpeedType();
       j["predicted_spacing_interval_sec"] = Units::SecondsTime(m_predicted_spacing_interval).value();
       j["pilot_delay_enabled"] = m_pilot_delay.IsPilotDelayOn();
       j["is_crossing_time_valid"] = is_crossing_time_valid;

--- a/include/imalgs/IMTimeBasedAchieve.h
+++ b/include/imalgs/IMTimeBasedAchieve.h
@@ -29,6 +29,9 @@
 
 namespace interval_management {
 namespace open_source {
+
+using namespace mitre::oss::simcore;
+
 class IMTimeBasedAchieve : public IMKinematicAchieve {
   public:
    IMTimeBasedAchieve();
@@ -41,9 +44,9 @@ class IMTimeBasedAchieve : public IMKinematicAchieve {
 
    virtual void IterationReset() override;
 
-   virtual aaesim::open_source::Guidance Update(
-         const aaesim::open_source::Guidance &previous_im_guidance,
-         const aaesim::open_source::DynamicsState &three_dof_dynamics_state,
+   virtual mitre::oss::simcore::Guidance Update(
+         const mitre::oss::simcore::Guidance &previous_im_guidance,
+         const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state,
          const interval_management::open_source::AircraftState &current_ownship_state,
          const interval_management::open_source::AircraftState &current_target_state,
          const std::vector<interval_management::open_source::AircraftState> &target_adsb_history) override;
@@ -72,12 +75,12 @@ class IMTimeBasedAchieve : public IMKinematicAchieve {
 
    void Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                    const AircraftIntent &ownship_aircraft_intent,
-                   aaesim::open_source::WeatherPrediction &weather_prediction,
+                   mitre::oss::simcore::WeatherPrediction &weather_prediction,
                    std::shared_ptr<TangentPlaneSequence> &position_converter) override;
 
   protected:
    virtual void CalculateIas(const Units::Length current_ownship_altitude,
-                             const aaesim::open_source::DynamicsState &three_dof_dynamics_state) override;
+                             const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state) override;
 
    virtual void CalculateMach(const Units::Time reference_ttg, const Units::Length current_ownship_altitude,
                               const Units::Mass current_mass);
@@ -85,9 +88,9 @@ class IMTimeBasedAchieve : public IMKinematicAchieve {
    virtual void RecordInternalObserverMetrics(
          const interval_management::open_source::AircraftState &current_ownship_state,
          const interval_management::open_source::AircraftState &current_target_state,
-         const aaesim::open_source::DynamicsState &dynamics_state, const Units::Speed unmodified_ias,
+         const mitre::oss::simcore::DynamicsState &dynamics_state, const Units::Speed unmodified_ias,
          const Units::Speed tas_command, const Units::Speed reference_velocity, const Units::Length reference_distance,
-         const aaesim::open_source::Guidance &guidance) override;
+         const mitre::oss::simcore::Guidance &guidance) override;
 
    void Copy(const IMTimeBasedAchieve &obj);
 
@@ -99,23 +102,23 @@ class IMTimeBasedAchieve : public IMKinematicAchieve {
    Units::Time m_predicted_spacing_interval;
 
   private:
-   aaesim::open_source::Guidance HandleAchieveStage(
+   mitre::oss::simcore::Guidance HandleAchieveStage(
          const interval_management::open_source::AircraftState &current_ownship_state,
          const interval_management::open_source::AircraftState &current_target_state,
          const std::vector<interval_management::open_source::AircraftState> &target_adsb_history,
-         const aaesim::open_source::DynamicsState &three_dof_dynamics_state,
-         aaesim::open_source::Guidance &guidance_out);
+         const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state,
+         mitre::oss::simcore::Guidance &guidance_out);
 
    void TestForTrafficAlignment(
          const interval_management::open_source::AircraftState &current_ownship_state,
          const std::vector<interval_management::open_source::AircraftState> &target_adsb_history);
 
-   aaesim::open_source::Guidance HandleMaintainStage(
+   mitre::oss::simcore::Guidance HandleMaintainStage(
          const interval_management::open_source::AircraftState &current_ownship_state,
          const interval_management::open_source::AircraftState &current_target_state,
          const std::vector<interval_management::open_source::AircraftState> &target_adsb_history,
-         const aaesim::open_source::DynamicsState &three_dof_dynamics_state,
-         const aaesim::open_source::Guidance &previous_im_guidance, aaesim::open_source::Guidance &guidance_out);
+         const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state,
+         const mitre::oss::simcore::Guidance &previous_im_guidance, mitre::oss::simcore::Guidance &guidance_out);
 
    const Units::Time CalculateMeasuredSpacingInterval(
          const interval_management::open_source::AircraftState &current_ownship_state,
@@ -133,7 +136,7 @@ class IMTimeBasedAchieve : public IMKinematicAchieve {
    void DoAlgorithmLogging(const interval_management::open_source::AircraftState &current_ownship_state,
                            const interval_management::open_source::AircraftState &current_target_state,
                            const Units::Length &reference_distance, const Units::Speed &tascommand,
-                           const aaesim::open_source::Guidance &guidance_out, const bool &is_crossing_time_valid) const;
+                           const mitre::oss::simcore::Guidance &guidance_out, const bool &is_crossing_time_valid) const;
 
    interval_management::open_source::AircraftState m_target_state_at_traffic_alignment;
    interval_management::open_source::AircraftState m_target_state_at_cdti_initiate_signal_receipt;
@@ -209,7 +212,7 @@ inline void IMTimeBasedAchieve::DoAlgorithmLogging(
       const interval_management::open_source::AircraftState &current_ownship_state,
       const interval_management::open_source::AircraftState &current_target_state,
       const Units::Length &reference_distance, const Units::Speed &tascommand,
-      const aaesim::open_source::Guidance &guidance_out, const bool &is_crossing_time_valid) const {
+      const mitre::oss::simcore::Guidance &guidance_out, const bool &is_crossing_time_valid) const {
    if (m_logger.getLogLevel() == log4cplus::TRACE_LOG_LEVEL) {
       using json = nlohmann::json;
       json j;

--- a/include/imalgs/IMTimeBasedAchieveMutableASG.h
+++ b/include/imalgs/IMTimeBasedAchieveMutableASG.h
@@ -35,6 +35,9 @@
 namespace interval_management {
 namespace open_source {
 
+using namespace mitre::oss::simcore;
+
+
 class IMTimeBasedAchieveMutableASG final : public IMTimeBasedAchieve {
   public:
    IMTimeBasedAchieveMutableASG();
@@ -47,9 +50,9 @@ class IMTimeBasedAchieveMutableASG final : public IMTimeBasedAchieve {
 
    virtual void IterationReset() override;
 
-   virtual aaesim::open_source::Guidance Update(
-         const aaesim::open_source::Guidance &previous_im_guidance,
-         const aaesim::open_source::DynamicsState &three_dof_dynamics_state,
+   virtual mitre::oss::simcore::Guidance Update(
+         const mitre::oss::simcore::Guidance &previous_im_guidance,
+         const mitre::oss::simcore::DynamicsState &three_dof_dynamics_state,
          const interval_management::open_source::AircraftState &current_ownship_state,
          const interval_management::open_source::AircraftState &current_target_state,
          const std::vector<interval_management::open_source::AircraftState> &target_adsb_history) override;
@@ -58,13 +61,13 @@ class IMTimeBasedAchieveMutableASG final : public IMTimeBasedAchieve {
 
    virtual void Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                            const AircraftIntent &ownship_aircraft_intent,
-                           aaesim::open_source::WeatherPrediction &weather_prediction) override;
+                           mitre::oss::simcore::WeatherPrediction &weather_prediction) override;
 
    bool load(DecodedStream *input) override;
 
    void Initialize(const OwnshipPredictionParameters &ownship_prediction_parameters,
                    const AircraftIntent &ownship_aircraft_intent,
-                   aaesim::open_source::WeatherPrediction &weather_prediction,
+                   mitre::oss::simcore::WeatherPrediction &weather_prediction,
                    std::shared_ptr<TangentPlaneSequence> &position_converter) override;
 
   protected:

--- a/include/imalgs/IMUtils.h
+++ b/include/imalgs/IMUtils.h
@@ -66,18 +66,18 @@ class IMUtils final {
    static bool GetCrossingTime(
          const Units::Length current_dtg,
          const std::vector<interval_management::open_source::AircraftState> &aircraft_state_history,
-         const std::vector<aaesim::open_source::HorizontalPath> &horizontal_path, Units::Time &crossing_time);
+         const std::vector<mitre::oss::simcore::HorizontalPath> &horizontal_path, Units::Time &crossing_time);
 
    static bool GetCrossingTime(
          const Units::Length current_dtg,
          const std::vector<interval_management::open_source::AircraftState> &aircraft_state_history,
-         const std::vector<aaesim::open_source::HorizontalPath> &horizontal_path, Units::Time &crossing_time,
+         const std::vector<mitre::oss::simcore::HorizontalPath> &horizontal_path, Units::Time &crossing_time,
          Units::Length &projected_x, Units::Length &projected_y);
 
    static bool GetCrossingTime(
          const Units::Length current_dtg,
          const std::vector<interval_management::open_source::AircraftState> &aircraft_state_history,
-         aaesim::open_source::AlongPathDistanceCalculator &distance_calculator, Units::Time &crossing_time,
+         mitre::oss::simcore::AlongPathDistanceCalculator &distance_calculator, Units::Time &crossing_time,
          Units::Length &projected_x, Units::Length &projected_y);
 
    static void CalculateMergePoint(const Units::Length x1, const Units::Length y1, const Units::Length x2,
@@ -86,48 +86,48 @@ class IMUtils final {
 
    static void CalculateTimeBasedExtrapolate(
          const Units::Length &ownship_dtg, const interval_management::open_source::AircraftState &oldest_target_state,
-         const std::vector<aaesim::open_source::HorizontalPath> &ownship_horizontal_traj,
+         const std::vector<mitre::oss::simcore::HorizontalPath> &ownship_horizontal_traj,
          Units::Time &extrapolated_target_time, Units::Length &projected_x, Units::Length &projected_y,
          Units::Length &projected_distance_to_go);
 
    static void CalculateTimeBasedExtrapolate(const Units::Length &ownship_dtg,
                                              const interval_management::open_source::AircraftState &oldest_target_state,
-                                             aaesim::open_source::AlongPathDistanceCalculator &distance_calculator,
+                                             mitre::oss::simcore::AlongPathDistanceCalculator &distance_calculator,
                                              Units::Time &extrapolated_target_time, Units::Length &projected_x,
                                              Units::Length &projected_y, Units::Length &projected_distance_to_go);
 
    static bool CalculateTargetStateAtTime(
          const interval_management::open_source::AircraftState &target_state,
-         const std::vector<aaesim::open_source::HorizontalPath> &ownship_horizontal_traj,
+         const std::vector<mitre::oss::simcore::HorizontalPath> &ownship_horizontal_traj,
          const Units::Time extrapolation_time, const Units::Angle ownship_true_heading,
          interval_management::open_source::AircraftState &extrapolation_state);
 
    static void GetTimeBasedExtrapolateState(
          const interval_management::open_source::AircraftState &current_ownship_state,
          const interval_management::open_source::AircraftState &oldest_target_state,
-         const std::vector<aaesim::open_source::HorizontalPath> &ownship_horizontal_traj,
-         const std::vector<aaesim::open_source::HorizontalPath> &target_horizontal_traj,
+         const std::vector<mitre::oss::simcore::HorizontalPath> &ownship_horizontal_traj,
+         const std::vector<mitre::oss::simcore::HorizontalPath> &target_horizontal_traj,
          Units::Time &measured_spacing_interval,
          interval_management::open_source::AircraftState &aircraft_state_to_return);
 
    static void GetPositionFromPathLength(const Units::Length distance_to_go_in,
-                                         const std::vector<aaesim::open_source::HorizontalPath> &horizontal_path_in,
+                                         const std::vector<mitre::oss::simcore::HorizontalPath> &horizontal_path_in,
                                          const Units::Angle ownship_true_heading, Units::Length &x_out,
                                          Units::Length &y_out, Units::UnsignedAngle &course_out,
                                          int &horizontal_path_index);
 
    static bool GetPathLengthFromPosition(const Units::Length x, const Units::Length y,
-                                         const std::vector<aaesim::open_source::HorizontalPath> &horizontal_path,
+                                         const std::vector<mitre::oss::simcore::HorizontalPath> &horizontal_path,
                                          Units::Length &distance_to_go, Units::Angle &track);
 
    // method to project target aircraft position onto ownship horizontal trajectory
    static bool ProjectTargetPosition(const Units::Length x_target, const Units::Length y_target,
-                                     const std::vector<aaesim::open_source::HorizontalPath> &ownship_horizontal_path,
+                                     const std::vector<mitre::oss::simcore::HorizontalPath> &ownship_horizontal_path,
                                      Units::Length &x_projected, Units::Length &y_projected, Units::Length &dtg);
 
    // method to get target aircraft position on ownship horizontal trajectory based upon distance to go
    static bool ProjectTargetPositionFromDistance(
-         const Units::Length dtg, const std::vector<aaesim::open_source::HorizontalPath> &ownship_horizontal_path,
+         const Units::Length dtg, const std::vector<mitre::oss::simcore::HorizontalPath> &ownship_horizontal_path,
          Units::Length &x_projected, Units::Length &y_projected);
 
    /**
@@ -140,7 +140,7 @@ class IMUtils final {
     */
    static void CalculateTargetStateAtDistance(
          const interval_management::open_source::AircraftState &target_state,
-         const std::vector<aaesim::open_source::HorizontalPath> &ownship_horizontal_traj,
+         const std::vector<mitre::oss::simcore::HorizontalPath> &ownship_horizontal_traj,
          const Units::Length extrapolation_distance, const Units::Angle ownship_true_heading,
          interval_management::open_source::AircraftState &extrapstate);
 
@@ -154,7 +154,7 @@ class IMUtils final {
     */
    static interval_management::open_source::AircraftState GetTargetStateOnOwnshipPathForDtg(
          const std::vector<interval_management::open_source::AircraftState> &target_adsb_history,
-         const std::vector<aaesim::open_source::HorizontalPath> &ownship_horizontal_path,
+         const std::vector<mitre::oss::simcore::HorizontalPath> &ownship_horizontal_path,
          const Units::Length target_distance, const Units::Angle ownship_true_heading);
 
    static Units::Time InterpolateTimeAtDtg(const Units::Length target_dtg, const Units::Time time1,
@@ -175,13 +175,13 @@ class IMUtils final {
     */
    static interval_management::open_source::AircraftState GetProjectedTargetState(
          const std::vector<interval_management::open_source::AircraftState> &target_state_history,
-         const std::vector<aaesim::open_source::HorizontalPath> &ownship_horizontal_traj, const Units::Time target_time,
+         const std::vector<mitre::oss::simcore::HorizontalPath> &ownship_horizontal_traj, const Units::Time target_time,
          const Units::Angle ownship_true_heading, bool &target_state_is_valid);
 
    static interval_management::open_source::AircraftState GetProjectedTargetState(
-         aaesim::open_source::AlongPathDistanceCalculator &distance_calculator,
+         mitre::oss::simcore::AlongPathDistanceCalculator &distance_calculator,
          const std::vector<interval_management::open_source::AircraftState> &target_state_history,
-         const std::vector<aaesim::open_source::HorizontalPath> &ownship_horizontal_traj, const Units::Time target_time,
+         const std::vector<mitre::oss::simcore::HorizontalPath> &ownship_horizontal_traj, const Units::Time target_time,
          const Units::Angle ownship_true_heading, bool &target_state_is_valid);
 
    static Units::SignedAngle CalculateTrackAngle(const std::list<Units::Angle> &angle_history);
@@ -193,9 +193,9 @@ class IMUtils final {
    static std::map<IMUtils::IMAlgorithmTypes, std::string> algorithm_type_dictionary;
 
    static interval_management::open_source::AircraftState ConvertToIntervalManagementAircraftState(
-         const aaesim::open_source::AircraftState &aircraft_state);
+         const mitre::oss::simcore::AircraftState &aircraft_state);
 
-   static aaesim::open_source::AircraftState ConvertToAaesimAircraftState(
+   static mitre::oss::simcore::AircraftState ConvertToAaesimAircraftState(
          const interval_management::open_source::AircraftState &aircraft_state);
 
   private:

--- a/include/imalgs/InternalObserver.h
+++ b/include/imalgs/InternalObserver.h
@@ -38,6 +38,9 @@
 namespace interval_management {
 namespace open_source {
 
+using namespace mitre::oss::simcore;
+
+
 class InternalObserver final {
   public:
    static void FatalError(const char *str) {
@@ -55,11 +58,11 @@ class InternalObserver final {
    void outputMergePointMetric();
    void processMergePointMetric();
    void outputClosestPointMetric();
-   void addPredictedWind(int id, const aaesim::open_source::WeatherPrediction &weatherPrediction);
+   void addPredictedWind(int id, const mitre::oss::simcore::WeatherPrediction &weatherPrediction);
    std::string predWindsHeading(int lastIx);
-   std::string predWindsData(int id, int row, const std::string &field, const aaesim::open_source::WindStack &mat);
+   std::string predWindsData(int id, int row, const std::string &field, const mitre::oss::simcore::WindStack &mat);
    std::string predTempData(int id, const std::string &field,
-                            const aaesim::open_source::WeatherPrediction &weatherPrediction);
+                            const mitre::oss::simcore::WeatherPrediction &weatherPrediction);
    void addAchieveRcd(size_t aircraftId, double tm, double target_ttg_to_ach, double own_ttg_to_ach,
                       double curr_distance, double reference_distance);
    NMObserver &GetNMObserver(int id);

--- a/include/imalgs/InternalObserverScenarioWriter.h
+++ b/include/imalgs/InternalObserverScenarioWriter.h
@@ -24,7 +24,7 @@
 #include "public/ScenarioEventNotifier.h"
 
 namespace interval_management::open_source {
-class InternalObserverScenarioWriter final : public aaesim::open_source::ScenarioEventNotifier {
+class InternalObserverScenarioWriter final : public mitre::oss::simcore::ScenarioEventNotifier {
   public:
    InternalObserverScenarioWriter() = default;
    ~InternalObserverScenarioWriter() = default;

--- a/include/imalgs/MOPSPredictedWindEvaluatorVersion1.h
+++ b/include/imalgs/MOPSPredictedWindEvaluatorVersion1.h
@@ -25,9 +25,15 @@
 
 namespace interval_management {
 namespace open_source {
-class MOPSPredictedWindEvaluatorVersion1 final : public aaesim::open_source::PredictedWindEvaluator {
+
+using namespace mitre::oss::simcore;
+
+
+using namespace mitre::oss::simcore;
+
+class MOPSPredictedWindEvaluatorVersion1 final : public mitre::oss::simcore::PredictedWindEvaluator {
   public:
-   const static std::shared_ptr<aaesim::open_source::PredictedWindEvaluator> &GetInstance();
+   const static std::shared_ptr<mitre::oss::simcore::PredictedWindEvaluator> &GetInstance();
 
    virtual ~MOPSPredictedWindEvaluatorVersion1();
 
@@ -43,8 +49,8 @@ class MOPSPredictedWindEvaluatorVersion1 final : public aaesim::open_source::Pre
     * @param predictedwindy wind in the y
     * @author sbowman
     */
-   virtual bool ArePredictedWindsAccurate(const aaesim::open_source::AircraftState &state,
-                                          const aaesim::open_source::WeatherPrediction &weatherPrediction,
+   virtual bool ArePredictedWindsAccurate(const mitre::oss::simcore::AircraftState &state,
+                                          const mitre::oss::simcore::WeatherPrediction &weatherPrediction,
                                           const Units::Speed reference_cas, const Units::Length reference_altitude,
                                           const std::shared_ptr<Atmosphere> &sensed_atmosphere) const;
 
@@ -52,7 +58,7 @@ class MOPSPredictedWindEvaluatorVersion1 final : public aaesim::open_source::Pre
    const static Units::Angle toleranceAngle;
    const static Units::Speed toleranceSpeed;
 
-   static std::shared_ptr<aaesim::open_source::PredictedWindEvaluator> mInstance;
+   static std::shared_ptr<mitre::oss::simcore::PredictedWindEvaluator> mInstance;
 
    MOPSPredictedWindEvaluatorVersion1();
 };

--- a/include/imalgs/MOPSPredictedWindEvaluatorVersion2.h
+++ b/include/imalgs/MOPSPredictedWindEvaluatorVersion2.h
@@ -25,11 +25,17 @@
 
 namespace interval_management {
 namespace open_source {
-class MOPSPredictedWindEvaluatorVersion2 final : public aaesim::open_source::PredictedWindEvaluator {
+
+using namespace mitre::oss::simcore;
+
+
+using namespace mitre::oss::simcore;
+
+class MOPSPredictedWindEvaluatorVersion2 final : public mitre::oss::simcore::PredictedWindEvaluator {
   public:
    static Units::KnotsSpeed MAX_PERMITTED_GROUNDSPEED_ERROR;
 
-   const static std::shared_ptr<aaesim::open_source::PredictedWindEvaluator> &GetInstance();
+   const static std::shared_ptr<mitre::oss::simcore::PredictedWindEvaluator> &GetInstance();
 
    virtual ~MOPSPredictedWindEvaluatorVersion2();
 
@@ -41,15 +47,15 @@ class MOPSPredictedWindEvaluatorVersion2 final : public aaesim::open_source::Pre
     * @param state and aircraft_state_vector that represents the most recent navigations state
     * @param weatherPrediction The predicted winds to be evaluated
     */
-   virtual bool ArePredictedWindsAccurate(const aaesim::open_source::AircraftState &state,
-                                          const aaesim::open_source::WeatherPrediction &weatherPrediction,
+   virtual bool ArePredictedWindsAccurate(const mitre::oss::simcore::AircraftState &state,
+                                          const mitre::oss::simcore::WeatherPrediction &weatherPrediction,
                                           const Units::Speed reference_cas, const Units::Length reference_altitude,
                                           const std::shared_ptr<Atmosphere> &sensed_atmosphere) const;
 
   private:
    static log4cplus::Logger m_logger;
 
-   static std::shared_ptr<aaesim::open_source::PredictedWindEvaluator> mInstance;
+   static std::shared_ptr<mitre::oss::simcore::PredictedWindEvaluator> mInstance;
 
    static void LogWindDisagreeMetaData(
          const Units::KelvinTemperature predicted_temperature, const Units::KelvinTemperature true_temperature,
@@ -58,7 +64,7 @@ class MOPSPredictedWindEvaluatorVersion2 final : public aaesim::open_source::Pre
          const Units::Length reference_altitude, const Units::FeetLength true_altitude,
          const Units::Speed reference_cas, const Units::KnotsSpeed tas1, const Units::KnotsSpeed tas2,
          const Units::KnotsSpeed gs1, const Units::KnotsSpeed gs2, const Units::Speed predicted_wind_x,
-         const Units::Speed predicted_wind_y, const aaesim::open_source::AircraftState &state);
+         const Units::Speed predicted_wind_y, const mitre::oss::simcore::AircraftState &state);
 
    MOPSPredictedWindEvaluatorVersion2();
 };

--- a/include/imalgs/MaintainMetric.h
+++ b/include/imalgs/MaintainMetric.h
@@ -27,6 +27,7 @@
 
 namespace interval_management {
 namespace open_source {
+
 class MaintainMetric final {
   public:
    MaintainMetric();

--- a/include/imalgs/MergePointMetric.h
+++ b/include/imalgs/MergePointMetric.h
@@ -29,6 +29,9 @@
 namespace interval_management {
 namespace open_source {
 
+using namespace mitre::oss::simcore;
+
+
 class MergePointMetric final {
   public:
    MergePointMetric();

--- a/include/imalgs/MergePointMetric.h
+++ b/include/imalgs/MergePointMetric.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <log4cplus/logger.h>
 #include <scalar/Length.h>
 
 #include <string>

--- a/include/imalgs/NMObserver.h
+++ b/include/imalgs/NMObserver.h
@@ -27,6 +27,7 @@
 namespace interval_management {
 namespace open_source {
 
+
 class NMObserver final {
   public:
    NMObserver() = default;

--- a/include/imalgs/NMObserverEntry.h
+++ b/include/imalgs/NMObserverEntry.h
@@ -22,6 +22,7 @@
 namespace interval_management {
 namespace open_source {
 
+
 class NMObserverEntry final {
   public:
    NMObserverEntry();

--- a/include/imalgs/PredictionFileKinematic.h
+++ b/include/imalgs/PredictionFileKinematic.h
@@ -28,6 +28,9 @@
 #include "public/PredictionFileBase.h"
 
 namespace interval_management::open_source {
+
+using namespace mitre::oss::simcore;
+
 class PredictionFileKinematic final : private PredictionFileBase, public OutputHandler {
   public:
    PredictionFileKinematic();
@@ -35,7 +38,7 @@ class PredictionFileKinematic final : private PredictionFileBase, public OutputH
    void Finish() override;
 
    void Gather(const int iteration, const Units::Time simulation_time, std::string aircraft_id,
-               const std::shared_ptr<const aaesim::open_source::FlightDeckApplication> &flightdeck_application);
+               const std::shared_ptr<const mitre::oss::simcore::FlightDeckApplication> &flightdeck_application);
 
   private:
    const bool TrajectoryWasRegenerated(const std::vector<PredictionData> &prediction_data_single_acid,

--- a/include/imalgs/Statistics.h
+++ b/include/imalgs/Statistics.h
@@ -26,6 +26,7 @@ using std::vector;
 namespace interval_management {
 namespace open_source {
 
+
 class Statistics final {
   public:
    Statistics();

--- a/include/imalgs/TrueDistances.h
+++ b/include/imalgs/TrueDistances.h
@@ -26,6 +26,7 @@
 
 namespace interval_management {
 namespace open_source {
+
 class TrueDistances final {
   public:
    static const Units::Time END_OF_ROUTE_CROSSING_TIME_TOLERANCE;

--- a/include/imalgs/WaypointLoader.h
+++ b/include/imalgs/WaypointLoader.h
@@ -33,13 +33,13 @@ class WaypointLoader final : public LoggingLoadable {
 
    bool load(DecodedStream *input) override;
 
-   const Waypoint &BuildWaypoint() const;
+   const mitre::oss::simcore::Waypoint &BuildWaypoint() const;
 
   private:
-   Waypoint waypoint_{};
+   mitre::oss::simcore::Waypoint waypoint_{};
 };
 
-inline const Waypoint &WaypointLoader::BuildWaypoint() const { return waypoint_; }
+inline const mitre::oss::simcore::Waypoint &WaypointLoader::BuildWaypoint() const { return waypoint_; }
 
 }  // namespace loaders
 }  // namespace interval_management

--- a/unittest/src/IntervalManagement/fim_aircraft_intent_tests.cpp
+++ b/unittest/src/IntervalManagement/fim_aircraft_intent_tests.cpp
@@ -1,0 +1,48 @@
+// ****************************************************************************
+// NOTICE
+//
+// (c) 2026 The MITRE Corporation. All Rights Reserved.
+// ****************************************************************************
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "imalgs/FIMAircraftIntent.h"
+#include "public/SingleTangentPlaneSequence.h"
+
+namespace interval_management::open_source::test {
+
+namespace {
+
+std::vector<Waypoint> BuildDescentWaypoints() {
+   return {Waypoint{"first", Units::DegreesAngle(35.0), Units::DegreesAngle(-77.0)},
+           Waypoint{"last", Units::DegreesAngle(36.0), Units::DegreesAngle(-76.0)}};
+}
+
+}  // namespace
+
+TEST(FIMAircraftIntentBuilder, InsertsWaypointAtRequestedIndex) {
+   SingleTangentPlaneSequence::ClearStaticMembers();
+   const auto intent = FIMAircraftIntent::Builder()
+                         .LoadWaypoints({}, {}, BuildDescentWaypoints())
+                         .InsertWaypointAtIndex(
+                               Waypoint{"inserted", Units::DegreesAngle(35.5), Units::DegreesAngle(-76.5)}, 1)
+                         .Build();
+
+   EXPECT_EQ(3U, intent.GetNumberOfWaypoints());
+   EXPECT_EQ(std::optional<std::string>{"inserted"}, intent.GetWaypointName(1));
+}
+
+TEST(FIMAircraftIntentBuilder, InsertsLocalPairAtRequestedIndex) {
+   SingleTangentPlaneSequence::ClearStaticMembers();
+   const auto intent = FIMAircraftIntent::Builder()
+                         .LoadWaypoints({}, {}, BuildDescentWaypoints())
+                         .InsertPairAtIndex("merge", Units::MetersLength(0.0), Units::MetersLength(0.0), 1)
+                         .Build();
+
+   EXPECT_EQ(3U, intent.GetNumberOfWaypoints());
+   EXPECT_EQ(std::optional<std::string>{"merge"}, intent.GetWaypointName(1));
+}
+
+}  // namespace interval_management::open_source::test

--- a/unittest/src/IntervalManagement/imalgo_tests.cpp
+++ b/unittest/src/IntervalManagement/imalgo_tests.cpp
@@ -24,8 +24,8 @@
 #include <memory>
 
 using namespace std;
-using namespace aaesim::open_source;
-using namespace aaesim::open_source::constants;
+using namespace mitre::oss::simcore;
+using namespace mitre::oss::simcore::constants;
 using namespace interval_management::open_source;
 
 namespace aaesim {
@@ -90,7 +90,7 @@ TEST(IMAlgorithm, API) {
    im_time_based_achieve->SetSlope(Units::KnotsInvertedSpeed(0));
    im_time_based_achieve->SetErrorDistance(Units::MetersLength(0));
    im_time_based_achieve->SetBlendWind(true);
-   auto no_delay = aaesim::open_source::StatisticalPilotDelay::NoDelay();
+   auto no_delay = mitre::oss::simcore::StatisticalPilotDelay::NoDelay();
    im_time_based_achieve->SetPilotDelay(no_delay);
 
    im_time_based_achieve->GetTargetTrpCrossingTime();
@@ -861,8 +861,8 @@ TEST(IMUtils, ConvertAircraftStates) {
                      actual_sensed_wind_perpendicular, actual_sensed_temperature, actual_psi);
 
    // This is the tested method
-   // convert to aaesim::open_source::AircraftState
-   const aaesim::open_source::AircraftState converted_state_1 = IMUtils::ConvertToAaesimAircraftState(test_state);
+   // convert to mitre::oss::simcore::AircraftState
+   const mitre::oss::simcore::AircraftState converted_state_1 = IMUtils::ConvertToAaesimAircraftState(test_state);
 
    // assert data transferred
    EXPECT_EQ(actual_id, converted_state_1.GetUniqueId());

--- a/unittest/src/IntervalManagement/interval_management.cmake
+++ b/unittest/src/IntervalManagement/interval_management.cmake
@@ -1,5 +1,6 @@
 set(IMALGORITHM_TEST_SOURCE
         ${CMAKE_CURRENT_LIST_DIR}/imalgo_tests.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/fim_aircraft_intent_tests.cpp
         ${CMAKE_CURRENT_LIST_DIR}/predicted_wind_evaluator_tests.cpp
         # ${CMAKE_CURRENT_LIST_DIR}/clearance_tests.cpp
         )

--- a/unittest/src/IntervalManagement/predicted_wind_evaluator_tests.cpp
+++ b/unittest/src/IntervalManagement/predicted_wind_evaluator_tests.cpp
@@ -26,7 +26,7 @@
 
 #include "gtest/gtest.h"
 
-using namespace aaesim::open_source;
+using namespace mitre::oss::simcore;
 using namespace interval_management::open_source;
 
 namespace aaesim {
@@ -41,7 +41,7 @@ class PredictedWindEvaluatorTest : public ::testing::Test {
         sensed_atmosphere(new USStandardAtmosphere1976()),
         weather_prediction(WeatherPrediction::CreateZeroWindPrediction(sensed_atmosphere)) {}
 
-   aaesim::open_source::AircraftState aircraft_state{};
+   mitre::oss::simcore::AircraftState aircraft_state{};
    Units::Speed reference_cas;
    Units::Length reference_altitude;
    std::shared_ptr<Atmosphere> sensed_atmosphere;

--- a/unittest/src/main.cpp
+++ b/unittest/src/main.cpp
@@ -23,7 +23,7 @@
 
 GTEST_API_ int main(int argc, char **argv) {
    log4cplus::Initializer initializer;
-   LoadLoggerProperties();
+   mitre::oss::simcore::LoadLoggerProperties();
    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
    LOG4CPLUS_INFO(logger, "Running main()");
    testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Update to `simcore` 2.0.0. This was an API change which triggered a refactor here. The refactor is large here, causing this library to have significant public changes. This refactor is release as 6.0.0.
- Also created `FIMAircraftIntent`
- Minimized use of new `mitre::oss::simcore::DefaultAircraftIntent`